### PR TITLE
Change ReadCString to use only \0 as terminator

### DIFF
--- a/src/Inferno.Core/LevelReader.cpp
+++ b/src/Inferno.Core/LevelReader.cpp
@@ -7,7 +7,7 @@
 namespace Inferno {
     void ReadLevelInfo(StreamReader& reader, Level& level) {
         if (level.Version >= 2)
-            level.Palette = reader.ReadCString(13);
+            level.Palette = reader.ReadStringToNewline(13);
 
         level.BaseReactorCountdown = level.Version >= 3 ? reader.ReadInt32() : 30;
         level.ReactorStrength = level.Version >= 4 ? reader.ReadInt32() : -1;

--- a/src/Inferno.Core/Streams.h
+++ b/src/Inferno.Core/Streams.h
@@ -117,12 +117,11 @@ namespace Inferno {
             return { b.data() };
         }
 
-        // Reads a null or newline terminated string up to the max length
+        // Reads a null terminated string up to the max length
         string ReadCString(size_t maxLen) {
             List<char> b(maxLen + 1);
             for (int i = 0; i < maxLen; i++) {
                 _stream->read(&b[i], sizeof(char));
-                if (b[i] == '\n') b[i] = '\0';
                 if (b[i] == '\0') break;
             }
             return { b.data() };


### PR DESCRIPTION
Looks like this is what is needed to use ReadCString for D3 Generic descriptions, which might contain newlines.