### PR TITLE
Added an option to toggle vsync

### DIFF
--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -68,7 +68,7 @@ namespace Inferno::Editor {
             ImGui::Separator();
 
             const auto labelWidth = 165 * Shell::DpiScale;
-            const auto columnHeight = 425 * Shell::DpiScale;
+            const auto columnHeight = 450 * Shell::DpiScale;
             ImGui::BeginChild("left", { Width / 2 - 25 * Shell::DpiScale, columnHeight });
 
 
@@ -438,7 +438,7 @@ namespace Inferno::Editor {
         }
 
         void OnUpdate() override {
-            ImGui::BeginChild("prop_panel", { -1, 800 * Shell::DpiScale });
+            ImGui::BeginChild("prop_panel", { -1, 825 * Shell::DpiScale });
 
             if (ImGui::BeginTabBar("##Tabs", ImGuiTabBarFlags_None)) {
                 MainOptionsTab();
@@ -495,7 +495,7 @@ namespace Inferno::Editor {
             Events::SettingsChanged();
 
             if (vsyncChanged) {
-                Render::Adapter->CreateWindowSizeDependentResources();
+                Render::Adapter->CreateWindowSizeDependentResources(true);
             }
 
             if (resourcesChanged) {

--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -120,8 +120,12 @@ namespace Inferno::Editor {
                 ImGui::TextDisabled("Graphics");
                 ImGui::NextColumn();
                 ImGui::NextColumn();
+                
+                ImGui::ColumnLabelEx("Vsync", "Prevents screen tearing, and limits maximum frame rate to the\nscreen's refresh rate. Can cause an increase in input latency.");
+                ImGui::Checkbox("##vsync", &_graphics.UseVsync);
+                ImGui::NextColumn();
 
-                ImGui::ColumnLabelEx("MSAA", "Multisample antialiasinging\n\nReduces jagged edges of polygons.\nHas a potentially high performance impact.");
+                ImGui::ColumnLabelEx("MSAA", "Multisample antialiasing\n\nReduces jagged edges of polygons.\nHas a potentially high performance impact.");
                 ImGui::SetNextItemWidth(-1);
 
                 auto msaa = [](int samples) {
@@ -466,6 +470,7 @@ namespace Inferno::Editor {
             CopyBindingEntries(_bindingEntries);
 
             bool resourcesChanged = false;
+            bool vsyncChanged = false;
             auto dataPathsChanged = _inferno.DataPaths != Settings::Inferno.DataPaths;
             if (dataPathsChanged || _inferno.Descent1Path != Settings::Inferno.Descent1Path || _inferno.Descent2Path != Settings::Inferno.Descent2Path) {
                 resourcesChanged = true;
@@ -479,11 +484,19 @@ namespace Inferno::Editor {
                 resourcesChanged = true;
             }
 
+            if (_graphics.UseVsync != Settings::Graphics.UseVsync) {
+                vsyncChanged = true;
+            }
+
             Settings::Inferno = _inferno;
             Settings::Editor = _editor;
             Settings::Graphics = _graphics;
             Settings::Save();
             Events::SettingsChanged();
+
+            if (vsyncChanged) {
+                Render::Adapter->CreateWindowSizeDependentResources();
+            }
 
             if (resourcesChanged) {
                 FileSystem::Init();

--- a/src/Inferno/Graphics/DeviceResources.h
+++ b/src/Inferno/Graphics/DeviceResources.h
@@ -35,7 +35,7 @@ namespace Inferno {
                         DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D32_FLOAT,
                         UINT backBufferCount = 2,
                         D3D_FEATURE_LEVEL minFeatureLevel = D3D_FEATURE_LEVEL_11_0,
-                        unsigned int flags = 0) noexcept(false);
+                        unsigned int flags = c_AllowTearing) noexcept(false);
         ~DeviceResources();
 
         DeviceResources(DeviceResources&&) = default;

--- a/src/Inferno/Graphics/DeviceResources.h
+++ b/src/Inferno/Graphics/DeviceResources.h
@@ -47,7 +47,7 @@ namespace Inferno {
         float RenderScale = 1.0; // Scaling applied to 3D render targets
 
         void CreateDeviceResources();
-        void CreateWindowSizeDependentResources();
+        void CreateWindowSizeDependentResources(bool forceSwapChainRebuild = false);
         void SetWindow(HWND window, int width, int height) noexcept;
         bool WindowSizeChanged(int width, int height);
         void HandleDeviceLost();

--- a/src/Inferno/Settings.cpp
+++ b/src/Inferno/Settings.cpp
@@ -31,6 +31,7 @@ namespace Inferno {
         node["MsaaSamples"] << s.MsaaSamples;
         node["ForegroundFpsLimit"] << s.ForegroundFpsLimit;
         node["BackgroundFpsLimit"] << s.BackgroundFpsLimit;
+        node["UseVsync"] << s.UseVsync;
         node["FilterMode"] << (int)s.FilterMode;
     }
 
@@ -45,6 +46,7 @@ namespace Inferno {
 
         ReadValue(node["ForegroundFpsLimit"], s.ForegroundFpsLimit);
         ReadValue(node["BackgroundFpsLimit"], s.BackgroundFpsLimit);
+        ReadValue(node["UseVsync"], s.UseVsync);
         ReadValue(node["FilterMode"], (int&)s.FilterMode);
         return s;
     }

--- a/src/Inferno/Settings.h
+++ b/src/Inferno/Settings.h
@@ -144,6 +144,7 @@ namespace Inferno {
         bool EnableProcedurals = true;
         int MsaaSamples = 1;
         int ForegroundFpsLimit = -1, BackgroundFpsLimit = 20;
+        bool UseVsync = true;
         bool NewLightMode = true;
         int ToneMapper = 1;
         TextureFilterMode FilterMode = TextureFilterMode::EnhancedPoint;


### PR DESCRIPTION
This isn't quite as clean as I'd like, but because the "allow tearing" swap chain flag can't be changed by a ResizeBuffers call, we (presumably) have to destroy and recreate the swap chain to toggle vsync. I maybe should have created a new function for this, but CreateWindowSizeDependentResources was right there, with almost everything I needed in it :P

(I also fixed the "antialiasinging" tooltip misspelling while I was in the file :D)