### PR TITLE
Implemented a queue for input events

### DIFF
--- a/src/Inferno/Editor/Editor.cpp
+++ b/src/Inferno/Editor/Editor.cpp
@@ -247,14 +247,14 @@ namespace Inferno::Editor {
     void CheckForMouselook() {
         auto mouselookKey = Bindings::Active.GetBindingKey(EditorAction::HoldMouselook);
 
-        if (Input::Mouse.middleButton == Input::MouseState::PRESSED ||
-            Input::Keyboard.IsKeyPressed(mouselookKey)) {
+        if (Input::IsMouseButtonPressed(Input::MouseButtons::Middle) ||
+            Input::IsKeyPressed(mouselookKey)) {
             auto mode = Settings::Editor.MiddleMouseMode == MiddleMouseMode::Mouselook ? Input::MouseMode::Mouselook : Input::MouseMode::Orbit;
             Input::SetMouseMode(mode);
         }
 
-        if (Input::Mouse.middleButton == Input::MouseState::RELEASED ||
-            Input::Keyboard.IsKeyReleased(mouselookKey))
+        if (Input::IsMouseButtonReleased(Input::MouseButtons::Middle) ||
+            Input::IsKeyReleased(mouselookKey))
             Input::SetMouseMode(Input::MouseMode::Normal);
     }
 

--- a/src/Inferno/Game.Player.cpp
+++ b/src/Inferno/Game.Player.cpp
@@ -182,7 +182,7 @@ namespace Inferno {
         // must check held keys inside of fixed updates so events aren't missed due to the state changing
         // on a frame that doesn't have a game tick
         if ((state == GameState::Editor && Input::IsKeyDown(Keys::Enter)) ||
-            (state != GameState::Editor && Input::Mouse.leftButton == Input::MouseState::HELD)) {
+            (state != GameState::Editor && Input::IsMouseButtonDown(Input::MouseButtons::Left))) {
             if (PrimaryState == FireState::None)
                 PrimaryState = FireState::Press;
             else if (PrimaryState == FireState::Press)
@@ -195,7 +195,7 @@ namespace Inferno {
                 PrimaryState = FireState::Release;
         }
 
-        if (state != GameState::Editor && Input::Mouse.rightButton == Input::MouseState::HELD) {
+        if (state != GameState::Editor && Input::IsMouseButtonDown(Input::MouseButtons::Right)) {
             if (SecondaryState == FireState::None)
                 SecondaryState = FireState::Press;
             else if (SecondaryState == FireState::Press)

--- a/src/Inferno/Input.h
+++ b/src/Inferno/Input.h
@@ -4,13 +4,21 @@
 #include <DirectXTK12/Keyboard.h>
 
 namespace Inferno::Input {
-    using MouseState = DirectX::Mouse::ButtonStateTracker::ButtonState;
-    inline DirectX::Keyboard::KeyboardStateTracker Keyboard;
-    inline DirectX::Mouse::ButtonStateTracker Mouse;
+    //using MouseState = DirectX::Mouse::ButtonStateTracker::ButtonState;
+    //inline DirectX::Keyboard::KeyboardStateTracker Keyboard;
+    //inline DirectX::Mouse::ButtonStateTracker Mouse;
+    enum MouseButtons : uint8_t {
+        Left,
+        Right,
+        Middle,
+        X1,
+        X2
+    };
+
     inline DirectX::SimpleMath::Vector2 MouseDelta;
     inline DirectX::SimpleMath::Vector2 MousePosition;
     inline int WheelDelta;
-    inline Vector2 DragStart; // Mouse drag start position in screen coordinates
+    inline DirectX::SimpleMath::Vector2 DragStart; // Mouse drag start position in screen coordinates
 
     inline bool ControlDown;
     inline bool ShiftDown;
@@ -25,6 +33,18 @@ namespace Inferno::Input {
 
     // Returns true when a key is first pressed
     bool IsKeyPressed(DirectX::Keyboard::Keys);
+
+    // Returns true when a key is first released
+    bool IsKeyReleased(DirectX::Keyboard::Keys);
+
+    // Returns true while a key is held down
+    bool IsMouseButtonDown(MouseButtons);
+
+    // Returns true when a key is first pressed
+    bool IsMouseButtonPressed(MouseButtons);
+
+    // Returns true when a key is first released
+    bool IsMouseButtonReleased(MouseButtons);
 
     void ResetState();
 
@@ -50,4 +70,15 @@ namespace Inferno::Input {
 
     // Workaround for the relative mouse mode not summing deltas properly
     void ProcessRawMouseInput(UINT message, WPARAM, LPARAM);
+
+    enum class EventType {
+        KeyPress,
+        KeyRelease,
+        MouseBtnPress,
+        MouseBtnRelease,
+        MouseWheel,
+        Reset
+    };
+
+    void QueueEvent(EventType type, WPARAM keyCode = 0, int64_t flags = 0);
 }


### PR DESCRIPTION
A few notes:
- There's a small logic change, in that Input::IsKeyDown will now return true when a key was pressed on a frame, as opposed to only returning true when it was "down" in the previous state; this is necessary because releasing a key on the same frame sets the state to "up" before the frame is finished
- It's possible that there is a better access pattern available, but this mostly fit in with the existing use of the IsKeyDown/etc. functions
- We might want to just slap a "using Keys = DirectX::Keyboard::Keys" into Input.h and use Input::Keys for everything instead of it being used in a number of more specific places (which if we then want to stop relying on the DXTK input stuff entirely, makes it easier to replace later), especially because it's the only part of the DXTK keyboard input that's still being relied upon
- Currently the DXTK mouse input is still being used because I wasn't sure what the best way to replace the non-mouselook input at line 200 of Input.cpp (i.e. in Input::Update())