### PR TITLE
Alias DirectX::Keyboard::Keys to Input::Keys and fix scrollwheel direction

### DIFF
--- a/src/Inferno/Application.cpp
+++ b/src/Inferno/Application.cpp
@@ -80,8 +80,6 @@ void Application::Initialize(int width, int height) {
     };
 }
 
-using Keys = Keyboard::Keys;
-
 void Application::Update() {}
 
 void Application::UpdateFpsLimit() {

--- a/src/Inferno/Editor/Bindings.cpp
+++ b/src/Inferno/Editor/Bindings.cpp
@@ -13,7 +13,7 @@
 
 using namespace DirectX;
 
-using Keys = DirectX::Keyboard::Keys;
+using Keys = Inferno::Input::Keys;
 
 namespace Inferno::Editor {
     namespace Commands {
@@ -483,7 +483,7 @@ namespace Inferno::Editor::Bindings {
         Active = Default;
     }
 
-    bool IsReservedKey(DirectX::Keyboard::Keys key) {
+    bool IsReservedKey(Keys key) {
         switch (key) {
             case Keys::LeftWindows:
             case Keys::RightWindows:

--- a/src/Inferno/Editor/Bindings.h
+++ b/src/Inferno/Editor/Bindings.h
@@ -2,6 +2,7 @@
 #include <DirectXTK12/Keyboard.h>
 #include "Types.h"
 #include "Command.h"
+#include "Input.h"
 
 namespace Inferno::Editor {
     enum class EditorAction {
@@ -84,7 +85,7 @@ namespace Inferno::Editor {
 
     struct EditorBinding {
         EditorAction Action{};
-        DirectX::Keyboard::Keys Key{};
+        Input::Keys Key{};
 
         bool Shift = false;
         bool Control = false;
@@ -144,9 +145,9 @@ namespace Inferno::Editor {
             return binding ? Input::IsKeyDown(binding->Key) : false;
         }
 
-        DirectX::Keyboard::Keys GetBindingKey(Editor::EditorAction action) {
+        Input::Keys GetBindingKey(Editor::EditorAction action) {
             auto binding = GetBinding(action);
-            return binding ? binding->Key : DirectX::Keyboard::Keys::None;
+            return binding ? binding->Key : Input::Keys::None;
         }
     };
 
@@ -155,6 +156,6 @@ namespace Inferno::Editor {
 
         void Update();
         void LoadDefaults();
-        bool IsReservedKey(DirectX::Keyboard::Keys);
+        bool IsReservedKey(Input::Keys);
     }
 }

--- a/src/Inferno/Editor/Editor.Camera.cpp
+++ b/src/Inferno/Editor/Editor.Camera.cpp
@@ -28,8 +28,8 @@ namespace Inferno::Editor {
 
         // Only allow scrollwheel zooming when not over ImGui
         if (!ImGui::GetIO().WantCaptureMouse) {
-            if (wheelDelta < 0) camera.ZoomIn();
-            if (wheelDelta > 0) camera.ZoomOut();
+            if (wheelDelta > 0) camera.ZoomIn();
+            if (wheelDelta < 0) camera.ZoomOut();
         }
     }
 

--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -4,6 +4,7 @@
 #include "WindowBase.h"
 #include "WindowsDialogs.h"
 #include "Editor/Bindings.h"
+#include "Input.h"
 
 namespace Inferno::Editor {
     class SettingsDialog final : public ModalWindowBase {
@@ -278,7 +279,7 @@ namespace Inferno::Editor {
                 ImGui::TableSetupColumn("Alt Shortcut");
                 ImGui::TableHeadersRow();
 
-                using Keys = DirectX::Keyboard::Keys;
+                using Keys = Input::Keys;
                 static int selectedBinding = -1;
                 static bool editAlt = false;
 
@@ -536,7 +537,7 @@ namespace Inferno::Editor {
         }
 
         static void CopyBindingEntries(span<BindingEntry> entries) {
-            using Keys = DirectX::Keyboard::Keys;
+            using Keys = Input::Keys;
             Bindings::Active.Clear();
 
             for (auto& entry : entries) {

--- a/src/Inferno/Game.Input.cpp
+++ b/src/Inferno/Game.Input.cpp
@@ -6,10 +6,9 @@
 #include "Settings.h"
 
 namespace Inferno {
-    using Keys = DirectX::Keyboard::Keys;
+    using Keys = Input::Keys;
 
     void HandleEditorDebugInput(float /*dt*/) {
-        using Keys = DirectX::Keyboard::Keys;
         auto& obj = Game::Level.Objects[0];
         auto& physics = obj.Physics;
 

--- a/src/Inferno/Game.Player.cpp
+++ b/src/Inferno/Game.Player.cpp
@@ -175,7 +175,7 @@ namespace Inferno {
 
 
     void Player::UpdateFireState() {
-        using Keys = DirectX::Keyboard::Keys;
+        using Keys = Input::Keys;
 
         auto state = Game::GetState();
 

--- a/src/Inferno/Game.cpp
+++ b/src/Inferno/Game.cpp
@@ -182,7 +182,7 @@ namespace Inferno::Game {
         }
     }
 
-    using Keys = Keyboard::Keys;
+    using Keys = Input::Keys;
 
     void CheckGlobalHotkeys() {
         if (Input::IsKeyPressed(Keys::F1))

--- a/src/Inferno/Input.cpp
+++ b/src/Inferno/Input.cpp
@@ -202,9 +202,9 @@ namespace Inferno::Input {
             MousePrev = MousePosition;
         }
 
-        AltDown = _keyboard.current[DirectX::Keyboard::Keys::LeftAlt] || _keyboard.current[DirectX::Keyboard::Keys::RightAlt];
-        ShiftDown = _keyboard.current[DirectX::Keyboard::Keys::LeftShift] || _keyboard.current[DirectX::Keyboard::Keys::RightShift];
-        ControlDown = _keyboard.current[DirectX::Keyboard::Keys::LeftControl] || _keyboard.current[DirectX::Keyboard::Keys::RightControl];
+        AltDown = _keyboard.current[Keys::LeftAlt] || _keyboard.current[Keys::RightAlt];
+        ShiftDown = _keyboard.current[Keys::LeftShift] || _keyboard.current[Keys::RightShift];
+        ControlDown = _keyboard.current[Keys::LeftControl] || _keyboard.current[Keys::RightControl];
 
         if (RightDragState == SelectionState::None)
             LeftDragState = UpdateDragState(MouseButtons::Left, LeftDragState);
@@ -223,15 +223,15 @@ namespace Inferno::Input {
         InitRawMouseInput(hwnd);
     }
 
-    bool IsKeyDown(DirectX::Keyboard::Keys key) {
+    bool IsKeyDown(Keys key) {
         return _keyboard.pressed[key] || _keyboard.previous[key];
     }
 
-    bool IsKeyPressed(DirectX::Keyboard::Keys key) {
+    bool IsKeyPressed(Keys key) {
         return _keyboard.pressed[key];
     }
 
-    bool IsKeyReleased(DirectX::Keyboard::Keys key) {
+    bool IsKeyReleased(Keys key) {
         return _keyboard.released[key];
     }
 

--- a/src/Inferno/Input.h
+++ b/src/Inferno/Input.h
@@ -4,9 +4,7 @@
 #include <DirectXTK12/Keyboard.h>
 
 namespace Inferno::Input {
-    //using MouseState = DirectX::Mouse::ButtonStateTracker::ButtonState;
-    //inline DirectX::Keyboard::KeyboardStateTracker Keyboard;
-    //inline DirectX::Mouse::ButtonStateTracker Mouse;
+    using Keys = DirectX::Keyboard::Keys;
     enum MouseButtons : uint8_t {
         Left,
         Right,
@@ -29,13 +27,13 @@ namespace Inferno::Input {
     void Initialize(HWND);
 
     // Returns true while a key is held down
-    bool IsKeyDown(DirectX::Keyboard::Keys);
+    bool IsKeyDown(Keys);
 
     // Returns true when a key is first pressed
-    bool IsKeyPressed(DirectX::Keyboard::Keys);
+    bool IsKeyPressed(Keys);
 
     // Returns true when a key is first released
-    bool IsKeyReleased(DirectX::Keyboard::Keys);
+    bool IsKeyReleased(Keys);
 
     // Returns true while a key is held down
     bool IsMouseButtonDown(MouseButtons);

--- a/src/Inferno/Physics.cpp
+++ b/src/Inferno/Physics.cpp
@@ -235,7 +235,7 @@ namespace Inferno {
         if (refresh_time == 0.0)
             refresh_time = t;
 
-        if (Input::IsKeyDown(DirectX::Keyboard::Keys::Add)) {
+        if (Input::IsKeyDown(Input::Keys::Add)) {
             if (index < Debug::ShipVelocities.size() && t >= refresh_time) {
                 //while (refresh_time < Game::ElapsedTime) {
                 Debug::ShipVelocities[index] = pd.Velocity.Length();

--- a/src/Inferno/Settings.cpp
+++ b/src/Inferno/Settings.cpp
@@ -257,7 +257,7 @@ namespace Inferno {
             binding.Alt = Seq::contains(tokens, "Alt");
             binding.Shift = Seq::contains(tokens, "Shift");
             binding.Control = Seq::contains(tokens, "Ctrl");
-            if (auto key = magic_enum::enum_cast<DirectX::Keyboard::Keys>(tokens.back()))
+            if (auto key = magic_enum::enum_cast<Input::Keys>(tokens.back()))
                 binding.Key = *key;
 
             // Note that it is valid for Key to equal None to indicate that the user unbound it on purpose


### PR DESCRIPTION
Note that the sign of WheelDelta is now the same as the Windows scrollwheel event - positive is up, negative is down.