### PR TITLE
Add "Snap to Plane" tool

### DIFF
--- a/src/Inferno/Editor/UI/EditorUI.cpp
+++ b/src/Inferno/Editor/UI/EditorUI.cpp
@@ -351,6 +351,7 @@ namespace Inferno::Editor {
                 ImGui::MenuItem("Sounds", nullptr, &Settings::Editor.Windows.Sound);
                 ImGui::MenuItem("Tunnel Builder", nullptr, &Settings::Editor.Windows.TunnelBuilder);
                 ImGui::MenuItem("Scale", nullptr, &Settings::Editor.Windows.Scale);
+                ImGui::MenuItem("Snap to Plane", nullptr, &Settings::Editor.Windows.SnapToPlane);
 
 #ifdef _DEBUG
                 ImGui::MenuItem("Briefing Editor", nullptr, &Settings::Editor.Windows.BriefingEditor);
@@ -926,6 +927,7 @@ namespace Inferno::Editor {
         _diagnosticWindow.Update();
         _briefingEditor.Update();
         _scaleWindow.Update();
+        _snapToPlaneWindow.Update();
 
         if (Editor::Gizmo.State == GizmoState::Dragging) {
             DrawGizmoTooltip();

--- a/src/Inferno/Editor/UI/EditorUI.h
+++ b/src/Inferno/Editor/UI/EditorUI.h
@@ -19,6 +19,7 @@
 #include "BriefingEditor.h"
 #include "ScaleWindow.h"
 #include "TextureEditor.h"
+#include "SnapToPlaneWindow.h"
 
 namespace Inferno::Editor {
 
@@ -69,6 +70,7 @@ namespace Inferno::Editor {
         DiagnosticWindow _diagnosticWindow;
         BriefingEditor _briefingEditor;
         ScaleWindow _scaleWindow;
+        SnapToPlaneWindow _snapToPlaneWindow;
         bool _showImguiDemo = false;
 
         Dictionary<DialogType, Ptr<ModalWindowBase>> _dialogs;

--- a/src/Inferno/Editor/UI/SnapToPlaneWindow.h
+++ b/src/Inferno/Editor/UI/SnapToPlaneWindow.h
@@ -1,0 +1,77 @@
+#pragma once
+
+namespace Inferno::Editor {
+    struct ProjectionAxisArgs {
+        Vector3 Axis;
+        Vector3 DrawLocation;
+        bool DrawLocationSet;
+
+        bool IsValid() const {
+            // DrawLocation isn't *technically* necessary to project,
+            // but it's easier to handle both things at once.
+            return DrawLocationSet && Axis.LengthSquared() > 0;
+        }
+    };
+    inline ProjectionAxisArgs SnapToPlaneArgs;
+
+    class SnapToPlaneWindow final : public WindowBase {
+        float _axis[3];
+
+    public:
+        SnapToPlaneWindow() : WindowBase("Snap Points to Plane", &Settings::Editor.Windows.SnapToPlane) {
+            // There isn't much in this window, so make it a little shorter
+            DefaultHeight = 200 * Shell::DpiScale;
+        }
+
+        void OnUpdate() override {
+            auto& args = SnapToPlaneArgs;
+
+            if (ImGui::Button("Pick Projection Axis")) {
+                auto face = Face::FromSide(Game::Level, Editor::Selection.Tag());
+                auto normal = face.VectorForEdge(Editor::Selection.Point);
+                _axis[0] = normal.x;
+                _axis[1] = normal.y;
+                _axis[2] = normal.z;
+                args.DrawLocation = face.Center();
+                args.DrawLocationSet = true;
+                args.Axis = normal;
+            }
+            ImGui::SameLine();
+            ImGui::SetNextItemWidth(-1);
+            if (ImGui::InputFloat3("##Axis", _axis)) {
+                Vector3 normalizedAxis = Vector3(_axis[0], _axis[1], _axis[2]);
+                normalizedAxis.Normalize();
+                args.Axis = normalizedAxis;
+                if (!args.DrawLocationSet) {
+                    args.DrawLocation = Face::FromSide(Game::Level, Editor::Selection.Tag()).Center();
+                    args.DrawLocationSet = true;
+                }
+            }
+
+            ImGui::Dummy({ 0, 20 });
+
+            {
+                DisableControls disable(!args.IsValid());
+                if (ImGui::Button("Project", { 100, 0 }))
+                    Project();
+                ImGui::HelpMarker("Projects marked points onto the plane defined by the current face.");
+            }
+        }
+
+        static void Project() {
+            auto& args = SnapToPlaneArgs;
+            auto face = Face::FromSide(Game::Level, Editor::Selection.Tag());
+            auto vertices = Editor::GetSelectedVertices();
+
+            for (auto& tag : vertices) {
+                auto& v = Game::Level.Vertices[tag];
+                // We're using the average plane of the selected face, not one of the two triangles.
+                v = ProjectRayOntoPlane(Ray(v, args.Axis), face.Center(), face.AverageNormal());
+            }
+
+            Game::Level.UpdateAllGeometricProps();
+            Editor::History.SnapshotLevel("Snap Points to Plane");
+            Editor::Events::LevelChanged();
+        }
+    };
+}

--- a/src/Inferno/Graphics/Render.Editor.cpp
+++ b/src/Inferno/Graphics/Render.Editor.cpp
@@ -423,6 +423,14 @@ namespace Inferno::Render {
         }
     }
 
+    void DrawSnapToPlaneAxis() {
+        if (Editor::SnapToPlaneArgs.IsValid()) {
+            auto arrowStart = Editor::SnapToPlaneArgs.DrawLocation - (Editor::SnapToPlaneArgs.Axis * 10);
+            auto arrowEnd = Editor::SnapToPlaneArgs.DrawLocation + (Editor::SnapToPlaneArgs.Axis * 10);
+            Debug::DrawArrow(arrowStart, arrowEnd, Colors::SelectionPrimary);
+        }
+    }
+
     void DrawEditor(ID3D12GraphicsCommandList* cmdList, Level& level) {
         if (Settings::Editor.ShowWireframe)
             DrawWireframe(level);
@@ -474,6 +482,9 @@ namespace Inferno::Render {
         //DrawFaceNormals(level);
         if (Settings::Editor.Windows.TunnelBuilder)
             DrawTunnelBuilder(level);
+
+        if (Settings::Editor.Windows.SnapToPlane)
+            DrawSnapToPlaneAxis();
 
         DrawRooms(level);
     }

--- a/src/Inferno/Inferno.vcxproj
+++ b/src/Inferno/Inferno.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="Editor\UI\BriefingEditor.h" />
     <ClInclude Include="Editor\UI\DiagnosticWindow.h" />
     <ClInclude Include="Editor\UI\ScaleWindow.h" />
+    <ClInclude Include="Editor\UI\SnapToPlaneWindow.h" />
     <ClInclude Include="Editor\UI\TextureEditor.h" />
     <ClInclude Include="Game.Text.h" />
     <ClInclude Include="Game.Segment.h" />

--- a/src/Inferno/Inferno.vcxproj.filters
+++ b/src/Inferno/Inferno.vcxproj.filters
@@ -448,6 +448,9 @@
     <ClInclude Include="Editor\UI\ScaleWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Editor\UI\SnapToPlaneWindow.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="shaders\compile.bat">

--- a/src/Inferno/Settings.h
+++ b/src/Inferno/Settings.h
@@ -118,6 +118,7 @@ namespace Inferno {
             bool BriefingEditor = false;
             bool TextureEditor = false;
             bool Scale = false;
+            bool SnapToPlane = false;
         } Windows;
 
         bool ShowWireframe = false;


### PR DESCRIPTION
This seems to do what I need; I figured I should share.
Some possible concerns:
- I put SnapToPlaneArgs in a UI header. That's kind of weird, but I'm not sure what a better place would be.
- The preview arrow for the projection axis is sharing the primary selection color, which I'm not sure you'd want.