### PR TITLE
Add "invert orbit X" toggle

### DIFF
--- a/src/Inferno/Editor/Editor.Camera.cpp
+++ b/src/Inferno/Editor/Editor.Camera.cpp
@@ -19,8 +19,9 @@ namespace Inferno::Editor {
                 camera.Pan(-delta.x * Settings::Editor.MoveSpeed * 0.001f, -delta.y * Settings::Editor.MoveSpeed * 0.001f);
             }
             else {
-                int inv = Settings::Editor.InvertOrbitY ? 1 : -1;
-                camera.Orbit(-delta.x * Settings::Editor.MouselookSensitivity, delta.y * inv * Settings::Editor.MouselookSensitivity);
+                int invX = Settings::Editor.InvertOrbitX ? 1 : -1;
+                int invY = Settings::Editor.InvertOrbitY ? 1 : -1;
+                camera.Orbit(delta.x * invX * Settings::Editor.MouselookSensitivity, delta.y * invY * Settings::Editor.MouselookSensitivity);
             }
         }
 

--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -90,8 +90,12 @@ namespace Inferno::Editor {
 
                 ImGui::NextColumn();
 
+                ImGui::ColumnLabel("Invert orbit X");
+                ImGui::Checkbox("##invert-orbit-x", &_editor.InvertOrbitX);
+                ImGui::NextColumn();
+
                 ImGui::ColumnLabel("Invert orbit Y");
-                ImGui::Checkbox("##invert-orbit", &_editor.InvertOrbitY);
+                ImGui::Checkbox("##invert-orbit-y", &_editor.InvertOrbitY);
                 ImGui::NextColumn();
 
 

--- a/src/Inferno/Settings.cpp
+++ b/src/Inferno/Settings.cpp
@@ -224,6 +224,7 @@ namespace Inferno {
         node["GizmoSize"] << s.GizmoSize;
         node["CrosshairSize"] << s.CrosshairSize;
         node["InvertY"] << s.InvertY;
+        node["InvertOrbitX"] << s.InvertOrbitX;
         node["InvertOrbitY"] << s.InvertOrbitY;
         node["MiddleMouseMode"] << (int)s.MiddleMouseMode;
         node["FieldOfView"] << s.FieldOfView;
@@ -296,6 +297,7 @@ namespace Inferno {
         ReadValue(node["GizmoSize"], s.GizmoSize);
         ReadValue(node["CrosshairSize"], s.CrosshairSize);
         ReadValue(node["InvertY"], s.InvertY);
+        ReadValue(node["InvertOrbitX"], s.InvertOrbitX);
         ReadValue(node["InvertOrbitY"], s.InvertOrbitY);
         ReadValue(node["MiddleMouseMode"], (int&)s.MiddleMouseMode);
         ReadValue(node["FieldOfView"], s.FieldOfView);

--- a/src/Inferno/Settings.h
+++ b/src/Inferno/Settings.h
@@ -102,6 +102,7 @@ namespace Inferno {
         float WireframeOpacity = 0.5f;
 
         bool InvertY = false;
+        bool InvertOrbitX = false;
         bool InvertOrbitY = false;
         float FieldOfView = 80;
         Editor::MiddleMouseMode MiddleMouseMode = Editor::MiddleMouseMode::Mouselook;


### PR DESCRIPTION
To reach parity with Blender, I needed to invert Inferno's orbit camera on _both_ axes, not just the Y axis. I added a toggle in settings to do this. I'm hoping it didn't mess up the layout too much. :)