### PR TITLE
Only mark textures on "texturable" sides

### DIFF
--- a/src/Inferno/Editor/Editor.Selection.cpp
+++ b/src/Inferno/Editor/Editor.Selection.cpp
@@ -854,6 +854,10 @@ namespace Inferno::Editor {
 
         for (int id = 0; id < level.Segments.size(); id++) {
             for (auto& sid : SideIDs) {
+                // Ignore connected sides unless there is a wall; otherwise the texture isn't really used
+                if (level.Segments[id].SideHasConnection(sid) && !level.Segments[id].SideIsWall(sid))
+                    continue;
+
                 auto& side = level.Segments[id].GetSide(sid);
                 bool match = true;
 


### PR DESCRIPTION
Use (effectively) the same logic for the mark-by-texture command that the texture list uses to decide if a texture is in use.
Note that neither case excludes end-of-exit-tunnel textures. I'm OK with this since it's at least consistent between the two now, but I'm happy to change it if you'd prefer.