### PR TITLE
Load textures for pasted segments

### DIFF
--- a/src/Inferno/Editor/Editor.Clipboard.cpp
+++ b/src/Inferno/Editor/Editor.Clipboard.cpp
@@ -4,6 +4,7 @@
 #include "Editor.Object.h"
 #include "Editor.Segment.h"
 #include "Editor.Wall.h"
+#include "Graphics/Render.h"
 
 namespace Inferno::Editor {
     struct SideClipboardData {
@@ -142,6 +143,9 @@ namespace Inferno::Editor {
                 else {
                     side.Wall = WallID::None;
                 }
+
+                Render::LoadTextureDynamic(side.TMap);
+                Render::LoadTextureDynamic(side.TMap2);
             }
 
             if (Settings::Editor.PasteSegmentSpecial) {


### PR DESCRIPTION
What it says on the box - previously, pasting segments wouldn't load the textures that the segments were using :P