### PR TITLE
Unlimited number of closed walls

### DIFF
--- a/src/Inferno.Core/Inferno.Core.vcxproj
+++ b/src/Inferno.Core/Inferno.Core.vcxproj
@@ -129,6 +129,7 @@
     <ClInclude Include="Types.h" />
     <ClInclude Include="Utility.h" />
     <ClInclude Include="Wall.h" />
+    <ClInclude Include="walls_container.h" />
     <ClInclude Include="Weapon.h" />
   </ItemGroup>
   <ItemGroup>
@@ -151,6 +152,7 @@
     <ClCompile Include="Polymodel.cpp" />
     <ClCompile Include="Segment.cpp" />
     <ClCompile Include="Sound.cpp" />
+    <ClCompile Include="walls_container.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/Inferno.Core/Inferno.Core.vcxproj.filters
+++ b/src/Inferno.Core/Inferno.Core.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClInclude Include="OutrageRoom.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="walls_container.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -140,6 +143,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="OutrageRoom.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="walls_container.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/Inferno.Core/Segment.cpp
+++ b/src/Inferno.Core/Segment.cpp
@@ -6,7 +6,7 @@
 namespace Inferno {
     bool Segment::SideIsSolid(SideID side, Level& level) const {
         if (SideHasConnection(side)) {
-            if (auto wall = level.TryGetWall(Sides[(int)side].Wall))
+            if (auto wall = level.Walls.TryGetWall(Sides[(int)side].Wall))
                 return wall->IsSolid(); // walls might be solid
 
             return false; // open side with no wall

--- a/src/Inferno.Core/Types.h
+++ b/src/Inferno.Core/Types.h
@@ -197,6 +197,10 @@ namespace Inferno {
     enum class ModelID : int32 { None = -1 };
     enum class MatcenID : uint8 { None = 255 };
     enum class TriggerID : uint8 { None = 255 };
+    enum class WallsSerialization {
+        STANDARD,
+        SHARED_SIMPLE_WALLS,
+    };
 
     namespace Models {
         constexpr auto PlaceableMine = ModelID(159); // D2 editor placeable mine

--- a/src/Inferno.Core/Wall.h
+++ b/src/Inferno.Core/Wall.h
@@ -58,6 +58,7 @@ namespace Inferno {
         sbyte cloak_value = 0; // Fade percentage if this wall is cloaked
 
         Option<bool> BlocksLight; // Editor override
+        mutable WallID SerializationId{ WallID::None };
 
         bool IsValid() const {
             return Tag.Segment != SegID::None;
@@ -87,6 +88,11 @@ namespace Inferno {
             value = std::clamp(value, 0.0f, 1.0f);
             cloak_value = sbyte(value / CloakStep);
         }
+
+        bool IsSimplyClosed() const {
+            return Type == WallType::Closed && ControllingTrigger == TriggerID::None;
+        }
+
     };
 
     struct ActiveDoor {

--- a/src/Inferno.Core/walls_container.cpp
+++ b/src/Inferno.Core/walls_container.cpp
@@ -1,0 +1,118 @@
+#include "pch.h"
+
+#include "walls_container.h"
+
+namespace Inferno {
+
+WallsContainer::Iterator WallsContainer::begin() {
+	return walls_.begin();
+}
+WallsContainer::Iterator WallsContainer::end() {
+	return walls_.end();
+}
+
+WallsContainer::ConstIterator WallsContainer::begin() const {
+    return walls_.begin();
+}
+WallsContainer::ConstIterator WallsContainer::end() const {
+    return walls_.end();
+}
+
+WallsContainer::SerializationGuard WallsContainer::PrepareSerialization() const {
+    serializableWalls_.emplace();
+    WallID firstClosed = WallID::None;
+    for (auto& wall : walls_) {
+        auto id = static_cast<WallID>(serializableWalls_->size());
+        if (!wall.IsSimplyClosed() || firstClosed == WallID::None)
+            serializableWalls_->push_back(&wall);
+        
+        if (wall.IsSimplyClosed()) {
+            if (firstClosed == WallID::None)
+                firstClosed = id;
+            id = firstClosed;
+        }
+
+        wall.SerializationId = id;
+    }
+    assert(serializableWalls_->size() <= static_cast<int>(WallID::Max));
+
+    return SerializationGuard(&serializableWalls_, [this](auto) {
+        serializableWalls_.reset();
+        for (auto& wall : walls_)
+            wall.SerializationId = WallID::None;
+    });
+}
+
+std::vector<Wall const*> const& WallsContainer::SeralizableWalls() const {
+    //fails if no Prepare has been called or the guard is destroyed
+    return *serializableWalls_;
+}
+
+Wall& WallsContainer::operator[](WallID id) {
+	return *TryGetWall(id);
+}
+Wall const& WallsContainer::operator[](WallID id) const {
+	return *TryGetWall(id);
+}
+
+Wall* WallsContainer::TryGetWall(TriggerID trigger) {
+    if (trigger == TriggerID::None) 
+        return nullptr;
+
+    for (auto& wall : *this) {
+        if (wall.Trigger == trigger)
+            return &wall;
+    }
+
+    return nullptr;
+}
+
+Wall* WallsContainer::TryGetWall(WallID id) {
+    if (id == WallID::None)
+        return nullptr;
+
+    auto iid = static_cast<int>(id);
+    return iid < walls_.size()
+        ? (walls_[iid].IsValid() ? &walls_[iid] : nullptr) //the current implementation actually keeps walls always valid: this seems to be some ghost from the past 
+        : nullptr;
+}
+
+Wall const* WallsContainer::TryGetWall(WallID id) const { 
+    return const_cast<WallsContainer&>(*this).TryGetWall(id);
+}
+
+WallID WallsContainer::Append(Wall wall) {
+    walls_.push_back(std::move(wall));
+    return static_cast<WallID>(walls_.size() - 1);
+}
+
+void WallsContainer::Erase(WallID id) {
+    walls_.erase(walls_.begin() + static_cast<size_t>(id));
+}
+
+bool WallsContainer::CanAdd(WallType type) const {
+    if (type == WallType::Closed) {
+        for (auto&& wall : walls_)
+            if (wall.IsSimplyClosed())
+                return true; //can always add another simply closed
+    }
+    //not a closed or no closed 
+    return ShrinkableSize() < static_cast<size_t>(WallID::Max) - 1;
+}
+
+size_t WallsContainer::Size() const {
+    return walls_.size();
+}
+size_t WallsContainer::ShrinkableSize() const {
+    size_t count = 0;
+    bool first = true;
+    for (auto&& w : walls_) {
+        if (!w.IsSimplyClosed() || first)
+            ++count;
+        if (first && w.IsSimplyClosed())
+            first = false;
+    }
+    return count;
+}
+
+}//namespace Inferno

--- a/src/Inferno.Core/walls_container.h
+++ b/src/Inferno.Core/walls_container.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "Wall.h"
+
+#include <vector>
+#include <unordered_map>
+
+namespace Inferno {
+
+class WallsContainer {
+	std::vector<Wall> walls_;
+	mutable std::optional<std::vector<Wall const*>> serializableWalls_;
+
+public:
+	using Iterator = std::vector<Wall>::iterator;
+	using ConstIterator = std::vector<Wall>::const_iterator;
+	using SerializationGuard = std::shared_ptr<void>;
+
+	Iterator begin();
+	Iterator end();
+
+	ConstIterator begin() const;
+	ConstIterator end() const;
+
+	size_t Size() const;
+	size_t ShrinkableSize() const;
+
+	SerializationGuard PrepareSerialization() const;
+	std::vector<Wall const*> const& SeralizableWalls() const;
+
+	Wall& operator[](WallID);
+	Wall const& operator[](WallID) const;
+
+	WallID Append(Wall w);
+	void Erase(WallID);
+
+	Wall* TryGetWall(TriggerID);
+	Wall* TryGetWall(WallID);
+	Wall const* TryGetWall(WallID) const;
+
+	bool CanAdd(WallType) const;
+};
+
+
+
+} //namespace Inferno

--- a/src/Inferno.Core/walls_container.h
+++ b/src/Inferno.Core/walls_container.h
@@ -10,11 +10,15 @@ namespace Inferno {
 class WallsContainer {
 	std::vector<Wall> walls_;
 	mutable std::optional<std::vector<Wall const*>> serializableWalls_;
+	size_t max_;
+	WallsSerialization option_{ WallsSerialization::STANDARD };
 
 public:
 	using Iterator = std::vector<Wall>::iterator;
 	using ConstIterator = std::vector<Wall>::const_iterator;
 	using SerializationGuard = std::shared_ptr<void>;
+
+	WallsContainer(size_t maxSize, WallsSerialization);
 
 	Iterator begin();
 	Iterator end();
@@ -39,6 +43,10 @@ public:
 	Wall const* TryGetWall(WallID) const;
 
 	bool CanAdd(WallType) const;
+	bool Overfilled() const;
+
+	WallsSerialization SerializationKind() const;
+	void SerializationKind(WallsSerialization);
 };
 
 

--- a/src/Inferno/Editor/Editor.Diagnostics.cpp
+++ b/src/Inferno/Editor/Editor.Diagnostics.cpp
@@ -53,7 +53,7 @@ namespace Inferno::Editor {
                 auto& side = level.GetSide(tag);
                 if (side.Wall == WallID::None) continue;
 
-                if (auto wall = level.TryGetWall(side.Wall)) {
+                if (auto wall = level.Walls.TryGetWall(side.Wall)) {
                     if (wall->Tag != tag) {
                         SPDLOG_WARN("Fixing mismatched wall tag on segment {}:{}", (int)tag.Segment, (int)tag.Side);
                         wall->Tag = tag;
@@ -67,8 +67,7 @@ namespace Inferno::Editor {
         }
 
         // Fix VClip 2
-        for (int id = 0; id < level.Walls.size(); id++) {
-            auto& wall = level.GetWall((WallID)id);
+        for (auto&& wall: level.Walls) {
             wall.LinkedWall = WallID::None; // Wall links are only valid during runtime
             if (wall.Clip == WClipID(2)) {
                 // ID 2 is bad and has no animation
@@ -444,7 +443,7 @@ namespace Inferno::Editor {
                         usedWalls.insert(side.Wall);
                     }
 
-                    if (auto wall = level.TryGetWall(side.Wall)) {
+                    if (auto wall = level.Walls.TryGetWall(side.Wall)) {
                         if (usedTriggers.contains(wall->Trigger)) {
                             auto msg = fmt::format("Trigger {} is already in use. Delete trigger on this side and insert a new one.", wall->Trigger);
                             results.push_back({ 0, { segid, sideId }, msg });

--- a/src/Inferno/Editor/Editor.IO.cpp
+++ b/src/Inferno/Editor/Editor.IO.cpp
@@ -15,7 +15,7 @@ namespace Inferno::Editor {
     constexpr auto METADATA_EXTENSION = "ied"; // inferno engine data
 
     size_t SaveLevel(Level& level, StreamWriter& writer) {
-        if (level.Walls.size() >= (int)WallID::Max)
+        if (level.Walls.ShrinkableSize() > (int)WallID::Max)
             throw Exception("Cannot save a level with more than 255 walls");
 
         DisableFlickeringLights(level);

--- a/src/Inferno/Editor/Editor.IO.cpp
+++ b/src/Inferno/Editor/Editor.IO.cpp
@@ -15,8 +15,9 @@ namespace Inferno::Editor {
     constexpr auto METADATA_EXTENSION = "ied"; // inferno engine data
 
     size_t SaveLevel(Level& level, StreamWriter& writer) {
-        if (level.Walls.ShrinkableSize() > (int)WallID::Max)
-            throw Exception("Cannot save a level with more than 255 walls");
+        if (level.Walls.ShrinkableSize() > level.Limits.Walls)
+            throw Exception(std::string("Cannot save a level with more than ") 
+                            + std::to_string(level.Limits.Walls) + " walls");
 
         DisableFlickeringLights(level);
         ResetFlickeringLightTimers(level);

--- a/src/Inferno/Editor/Editor.IO.cpp
+++ b/src/Inferno/Editor/Editor.IO.cpp
@@ -100,7 +100,10 @@ namespace Inferno::Editor {
         if (!file.read((char*)buffer.data(), size))
             throw Exception("Error reading file");
 
-        auto level = Level::Deserialize(buffer);
+        auto level = Level::Deserialize(buffer, 
+                                        Settings::Editor.UseSharedClosedWalls 
+                                        ? WallsSerialization::SHARED_SIMPLE_WALLS 
+                                        : WallsSerialization::STANDARD);
         level.FileName = path.filename().string();
         level.Path = path;
 
@@ -304,14 +307,16 @@ namespace Inferno::Editor {
 
     void OnSave();
 
-    void NewLevel(string name, string fileName, int16 version, bool addToHog) {
+    void NewLevel(string name, string const& fileName, int16 version, bool addToHog) {
         if (!addToHog)
             Game::UnloadMission();
 
-        Level level;
-        level.Name = name;
-        level.Version = version;
-        level.GameVersion = version == 1 ? 25 : 32;
+        Level level(version, 
+                    Settings::Editor.UseSharedClosedWalls 
+                    ? WallsSerialization::SHARED_SIMPLE_WALLS 
+                    : WallsSerialization::STANDARD);;
+        level.Name = std::move(name); //don't use name afterwards
+
         auto ext = level.IsDescent1() ? ".rdl" : ".rl2";
         level.FileName = fileName.substr(0, 8) + ext;
 

--- a/src/Inferno/Editor/Editor.IO.h
+++ b/src/Inferno/Editor/Editor.IO.h
@@ -8,7 +8,7 @@ namespace Inferno::Editor {
     // Creates a backup of a file using the provided extension
     void BackupFile(const filesystem::path& path, string_view ext = ".bak");
 
-    void NewLevel(string name, string fileName, int16 version, bool addToHog);
+    void NewLevel(string name, string const& fileName, int16 version, bool addToHog);
     void CheckForAutosave();
     void ResetAutosaveTimer();
     void WritePlaytestLevel(filesystem::path missionFolder, Level& level, HogFile* mission);

--- a/src/Inferno/Editor/Editor.Lighting.cpp
+++ b/src/Inferno/Editor/Editor.Lighting.cpp
@@ -219,7 +219,7 @@ namespace Inferno::Editor {
 
         if (side.Wall == WallID::None) return true; // not a wall and this side is open
 
-        auto& wall = level.GetWall(side.Wall);
+        auto& wall = level.Walls[side.Wall];
         if (wall.BlocksLight) return !(*wall.BlocksLight); // User defined
 
         switch (wall.Type) {
@@ -260,7 +260,7 @@ namespace Inferno::Editor {
         auto& side = seg.GetSide(sideId);
         if (side.Wall == WallID::None) return false; // no wall
 
-        auto& wall = level.GetWall(side.Wall);
+        auto& wall = level.Walls[side.Wall];
         switch (wall.Type) {
             case WallType::FlyThroughTrigger:
             case WallType::None:

--- a/src/Inferno/Editor/Editor.Segment.cpp
+++ b/src/Inferno/Editor/Editor.Segment.cpp
@@ -307,8 +307,8 @@ namespace Inferno::Editor {
             List<WallID> walls;
 
             // Remove walls on this seg
-            for (int16 wallId = 0; wallId < level.Walls.size(); wallId++) {
-                if (level.Walls[wallId].Tag.Segment == segId)
+            for (int16 wallId = 0; wallId < level.Walls.Size(); wallId++) {
+                if (level.Walls[static_cast<WallID>(wallId)].Tag.Segment == segId)
                     walls.push_back((WallID)wallId);
             }
 

--- a/src/Inferno/Editor/Editor.Selection.cpp
+++ b/src/Inferno/Editor/Editor.Selection.cpp
@@ -25,7 +25,7 @@ namespace Inferno::Editor {
             for (auto& side : SideIDs) {
                 if (!includeInvisible) {
                     bool visibleWall = false;
-                    if (auto wall = level.TryGetWall(seg.Sides[(int)side].Wall))
+                    if (auto wall = level.Walls.TryGetWall(seg.Sides[(int)side].Wall))
                         visibleWall = Settings::Editor.EnableWallMode || wall->Type != WallType::FlyThroughTrigger;
 
                     if (seg.SideHasConnection(side) && !visibleWall) continue;
@@ -402,7 +402,7 @@ namespace Inferno::Editor {
     }
 
     void EditorSelection::SelectByWall(WallID id) {
-        if (auto wall = Game::Level.TryGetWall(id)) {
+        if (auto wall = Game::Level.Walls.TryGetWall(id)) {
             Segment = wall->Tag.Segment;
             Side = wall->Tag.Side;
         }
@@ -695,7 +695,7 @@ namespace Inferno::Editor {
     // check if any of the sides with these edges are walls
     bool EdgeHasWall(Level& level, Segment& seg, PointID v0, PointID v1) {
         for (auto& sid : SideIDs) {
-            auto wall = level.TryGetWall(seg.GetSide(sid).Wall);
+            auto wall = level.Walls.TryGetWall(seg.GetSide(sid).Wall);
             if (!wall) continue;
             if (wall->Type == WallType::FlyThroughTrigger) continue;
 
@@ -788,7 +788,7 @@ namespace Inferno::Editor {
         if (!level.SegmentExists(tag)) return false;
         auto [seg, side] = level.GetSegmentAndSide(tag);
 
-        if (auto wall = level.TryGetWall(side.Wall)) {
+        if (auto wall = level.Walls.TryGetWall(side.Wall)) {
             return wall->Type != WallType::FlyThroughTrigger;
         }
 

--- a/src/Inferno/Editor/Editor.Wall.cpp
+++ b/src/Inferno/Editor/Editor.Wall.cpp
@@ -54,25 +54,12 @@ namespace Inferno::Editor {
 
     namespace {
         WallID AddWall(Level& level, Tag tag) {
-            //assert(level.Walls.CanAddWall(type));
+            //!: assert(level.Walls.CanAddWall(type)); <- this should be checked in the calling code
+
             if (!level.SegmentExists(tag.Segment)) return WallID::None;
             auto [seg, side] = level.GetSegmentAndSide(tag);
 
-            //WallID wallId = [&] {
-            //    // Find an unused wall slot
-            //    for (int i = 0; i < level.Walls.size(); i++) {
-            //        auto& wall = level.GetWall(WallID(i));
-            //        if (wall.Tag.Segment == SegID::None)
-            //            return WallID(i);
-            //    }
-
-            //    // Allocate a new wall
-            //    level.Walls.emplace_back();
-            //    return WallID(level.Walls.size() - 1);
-            //}();
             Wall wall;
-
-            //        auto& wall = level.GetWall(wallId);
             wall.Tag = tag;
             auto id = level.Walls.Append(wall);
             side.Wall = id;
@@ -197,7 +184,7 @@ namespace Inferno::Editor {
         if (wall.Type == type) 
             return;
         if (wall.IsSimplyClosed())
-            if (!level.Walls.CanAdd(type))                 {
+            if (!level.Walls.CanAdd(type)) {
                 SPDLOG_WARN("Can not change the wall type: it will increase walls count over {}", level.Limits.Walls);
                 return;
             }

--- a/src/Inferno/Editor/Editor.Wall.cpp
+++ b/src/Inferno/Editor/Editor.Wall.cpp
@@ -138,14 +138,12 @@ namespace Inferno::Editor {
 
     void AddTriggerTarget(Level& level, TriggerID id, Tag target) {
         auto wall = level.TryGetWall(target);
-        if (!wall) {
-            SPDLOG_WARN("Can not find wall for ({}, {})", target.Segment, target.Side);
-            return;
-        }
+        
         //if the wall was a Closed one and had no controlling trigger
         //it probably did not count against the max wall count
         //so we have to check if it is possible to add it back to the wall bookkeeping
-        if (wall->IsSimplyClosed() && !level.Walls.CanAdd(WallType::WallTrigger)) //WallTrigger is here just as something that is not Closed
+        if (wall && wall->IsSimplyClosed() 
+            && !level.Walls.CanAdd(WallType::WallTrigger)) //WallTrigger is here just as something that is not Closed
         {
             SPDLOG_WARN("Can not add wall as target: it will cause the wall amount to exceed {}", level.Limits.Walls);
             return;
@@ -155,9 +153,8 @@ namespace Inferno::Editor {
         if (!trigger) return;
         trigger->Targets.Add(target);
 
-        if (auto wall = level.TryGetWall(target)) {
+        if (wall)
             wall->ControllingTrigger = id;
-        }
     }
 
     bool RemoveWall(Level& level, WallID id) {

--- a/src/Inferno/Editor/Editor.Wall.cpp
+++ b/src/Inferno/Editor/Editor.Wall.cpp
@@ -3,13 +3,14 @@
 #include "Editor.Wall.h"
 #include "Graphics/Render.h"
 #include "Editor.Texture.h"
+#include "logging.h"
 
 namespace Inferno::Editor {
     bool FixWallClip(Level& level, Wall& wall) {
-        if (!level.SegmentExists(wall.Tag)) return false;
-        auto& side = level.GetSide(wall.Tag);
-
         if (wall.Type == WallType::Door || wall.Type == WallType::Destroyable) {
+            if (!level.SegmentExists(wall.Tag)) return false;
+            auto& side = level.GetSide(wall.Tag);
+
             // If a clip is selected assign it
             auto id1 = Resources::GetWallClipID(side.TMap);
             if (auto wc = Resources::TryGetWallClip(id1)) {
@@ -51,31 +52,36 @@ namespace Inferno::Editor {
         return id;
     }
 
-    WallID AddWall(Level& level, Tag tag) {
-        if (!level.SegmentExists(tag.Segment)) return WallID::None;
-        auto [seg, side] = level.GetSegmentAndSide(tag);
+    namespace {
+        WallID AddWall(Level& level, Tag tag) {
+            //assert(level.Walls.CanAddWall(type));
+            if (!level.SegmentExists(tag.Segment)) return WallID::None;
+            auto [seg, side] = level.GetSegmentAndSide(tag);
 
-        WallID wallId = [&] {
-            // Find an unused wall slot
-            for (int i = 0; i < level.Walls.size(); i++) {
-                auto& wall = level.GetWall(WallID(i));
-                if (wall.Tag.Segment == SegID::None)
-                    return WallID(i);
-            }
+            //WallID wallId = [&] {
+            //    // Find an unused wall slot
+            //    for (int i = 0; i < level.Walls.size(); i++) {
+            //        auto& wall = level.GetWall(WallID(i));
+            //        if (wall.Tag.Segment == SegID::None)
+            //            return WallID(i);
+            //    }
 
-            // Allocate a new wall
-            level.Walls.emplace_back();
-            return WallID(level.Walls.size() - 1);
-        }();
+            //    // Allocate a new wall
+            //    level.Walls.emplace_back();
+            //    return WallID(level.Walls.size() - 1);
+            //}();
+            Wall wall;
 
-        auto& wall = level.GetWall(wallId);
-        wall.Tag = tag;
-        side.Wall = wallId;
-        return wallId;
-    }
+            //        auto& wall = level.GetWall(wallId);
+            wall.Tag = tag;
+            auto id = level.Walls.Append(wall);
+            side.Wall = id;
+            return id;
+        }
+    }//namespace
 
     TriggerID AddTrigger(Level& level, WallID wallId, TriggerType type) {
-        if (auto wall = level.TryGetWall(wallId)) {
+        if (auto wall = level.Walls.TryGetWall(wallId)) {
             wall->Trigger = (TriggerID)level.Triggers.size();
             auto& trigger = level.Triggers.emplace_back();
             trigger.Type = type;
@@ -86,7 +92,7 @@ namespace Inferno::Editor {
     }
 
     TriggerID AddTrigger(Level& level, WallID wallId, TriggerFlagD1 flags) {
-        if (auto wall = level.TryGetWall(wallId)) {
+        if (auto wall = level.Walls.TryGetWall(wallId)) {
             wall->Trigger = (TriggerID)level.Triggers.size();
             auto& trigger = level.Triggers.emplace_back();
             trigger.FlagsD1 = flags;
@@ -104,14 +110,12 @@ namespace Inferno::Editor {
             if (wall.ControllingTrigger == id)
                 wall.ControllingTrigger = TriggerID::None;
 
-            if (wall.ControllingTrigger > id)
-                wall.ControllingTrigger = TriggerID((int)wall.ControllingTrigger - 1);
+            if (wall.ControllingTrigger != TriggerID::None && wall.ControllingTrigger > id)
+                wall.ControllingTrigger--;
 
             if (wall.Trigger == id)
                 wall.Trigger = TriggerID::None;
-        }
 
-        for (auto& wall : level.Walls) {
             if (wall.Trigger != TriggerID::None && wall.Trigger > id)
                 wall.Trigger--;
         }
@@ -133,14 +137,26 @@ namespace Inferno::Editor {
     }
 
     void AddTriggerTarget(Level& level, TriggerID id, Tag target) {
+        auto wall = level.TryGetWall(target);
+        if (!wall) {
+            SPDLOG_WARN("Can not find wall for ({}, {})", target.Segment, target.Side);
+            return;
+        }
+        //if the wall was a Closed one and had no controlling trigger
+        //it probably did not count against the max wall count
+        //so we have to check if it is possible to add it back to the wall bookkeeping
+        if (wall->IsSimplyClosed() && !level.Walls.CanAdd(WallType::WallTrigger)) //WallTrigger is here just as something that is not Closed
+        {
+            SPDLOG_WARN("Can not add wall as target: it will cause the wall amount to exceed {}", level.Limits.Walls);
+            return;
+        }
+
         auto trigger = level.TryGetTrigger(id);
         if (!trigger) return;
         trigger->Targets.Add(target);
 
-        // clear source trigger from wall it was targeting
         if (auto wall = level.TryGetWall(target)) {
-            if (wall->ControllingTrigger == id)
-                wall->ControllingTrigger = TriggerID::None;
+            wall->ControllingTrigger = id;
         }
     }
 
@@ -148,7 +164,7 @@ namespace Inferno::Editor {
         if (id == WallID::None) return false;
 
         {
-            auto wall = level.TryGetWall(id);
+            auto wall = level.Walls.TryGetWall(id);
             if (!wall) return false;
             auto seg = level.TryGetSegment(wall->Tag.Segment);
             if (!seg) return false;
@@ -175,13 +191,19 @@ namespace Inferno::Editor {
             }
         }
 
-        level.Walls.erase(level.Walls.begin() + (int)id);
+        level.Walls.Erase(id);
         Events::LevelChanged();
         return true;
     }
 
     void InitWall(Level& level, Wall& wall, WallType type) {
-        if (wall.Type == type) return;
+        if (wall.Type == type) 
+            return;
+        if (wall.IsSimplyClosed())
+            if (!level.Walls.CanAdd(type))                 {
+                SPDLOG_WARN("Can not change the wall type: it will increase walls count over {}", level.Limits.Walls);
+                return;
+            }
 
         if (type == WallType::Destroyable)
             wall.HitPoints = 100;
@@ -206,7 +228,7 @@ namespace Inferno::Editor {
     }
 
     WallID AddWall(Level& level, Tag tag, WallType type, LevelTexID tmap1, LevelTexID tmap2, WallFlag flags) {
-        if (level.Walls.size() + 1 >= (int)WallID::Max) {
+        if (!level.Walls.CanAdd(type)) {
             SetStatusMessageWarn("Cannot have more than {} walls in a level", WallID::Max);
             return WallID::None;
         }
@@ -238,8 +260,8 @@ namespace Inferno::Editor {
             return WallID::None;
         }
 
-        auto& wall = level.GetWall(wallId);
-        wall.Tag = tag;
+        auto& wall = level.Walls[wallId];
+        //wall.Tag = tag;
         wall.Flags = flags;
         InitWall(level, wall, type);
         side.TMap = tmap1;

--- a/src/Inferno/Editor/Editor.cpp
+++ b/src/Inferno/Editor/Editor.cpp
@@ -665,7 +665,7 @@ namespace Inferno::Editor {
 
         void GoToExit() {
             if (auto tid = Seq::findIndex(Game::Level.Triggers, IsExit)) {
-                if (auto wall = Game::Level.TryGetWall((TriggerID)*tid)) {
+                if (auto wall = Game::Level.Walls.TryGetWall((TriggerID)*tid)) {
                     Selection.SetSelection(wall->Tag);
                     FocusSegment();
                     return;
@@ -677,7 +677,7 @@ namespace Inferno::Editor {
 
         void GoToSecretExit() {
             if (auto tid = Seq::findIndex(Game::Level.Triggers, IsSecretExit)) {
-                if (auto wall = Game::Level.TryGetWall((TriggerID)*tid)) {
+                if (auto wall = Game::Level.Walls.TryGetWall((TriggerID)*tid)) {
                     Selection.SetSelection(wall->Tag);
                     FocusSegment();
                     return;

--- a/src/Inferno/Editor/UI/DiagnosticWindow.h
+++ b/src/Inferno/Editor/UI/DiagnosticWindow.h
@@ -192,7 +192,7 @@ namespace Inferno::Editor {
                     ImGui::Text("%i", _robots);
 
                     ImGui::TableRowLabel("Walls");
-                    ImGui::Text("%i", level.Walls.size());
+                    ImGui::Text("%i (%i)", level.Walls.Size(), level.Walls.ShrinkableSize());
                     ImGui::TableNextColumn();
                     ImGui::Text("%i", level.Limits.Walls);
 

--- a/src/Inferno/Editor/UI/PropertyEditor.Segment.cpp
+++ b/src/Inferno/Editor/UI/PropertyEditor.Segment.cpp
@@ -82,7 +82,7 @@ namespace Inferno::Editor {
 
     bool TriggerPropertiesD1(Level& level, WallID wid) {
         bool snapshot = false;
-        auto wall = level.TryGetWall(wid);
+        auto wall = level.Walls.TryGetWall(wid);
         DisableControls disable(!wall);
 
         auto trigger = wall ? level.TryGetTrigger(wall->Trigger) : nullptr;
@@ -135,7 +135,7 @@ namespace Inferno::Editor {
 
     bool TriggerPropertiesD2(Level& level, WallID wallId) {
         bool snapshot = false;
-        auto wall = level.TryGetWall(wallId);
+        auto wall = level.Walls.TryGetWall(wallId);
         auto tid = level.GetTriggerID(wallId);
         auto trigger = level.TryGetTrigger(wallId);
         DisableControls disable(!wall);
@@ -741,9 +741,9 @@ namespace Inferno::Editor {
 
     // Returns true if any wall properties changed
     bool WallProperties(Level& level, WallID id) {
-        auto wall = level.TryGetWall(id);
+        auto wall = level.Walls.TryGetWall(id);
         auto tag = Editor::Selection.Tag();
-        auto other = level.TryGetWall(level.GetConnectedWall(tag));
+        auto other = level.Walls.TryGetWall(level.GetConnectedWall(tag));
         bool open = ImGui::TableBeginTreeNode("Wall type");
 
         auto wallType = wall ? wall->Type : WallType::None;
@@ -768,11 +768,11 @@ namespace Inferno::Editor {
                 }
 
                 for (auto& markedId : GetSelectedWalls()) {
-                    auto& markedWall = level.GetWall(markedId);
+                    auto& markedWall = level.Walls[markedId];
                     markedWall.Clip = wall->Clip;
                     OnChangeWallClip(level, markedWall);
 
-                    auto markedOther = level.TryGetWall(level.GetConnectedWall(markedId));
+                    auto markedOther = level.Walls.TryGetWall(level.GetConnectedWall(markedId));
                     if (Settings::Editor.EditBothWallSides && markedOther && markedOther->Type == markedWall.Type) {
                         markedOther->Clip = wall->Clip;
                         OnChangeWallClip(level, *markedOther);
@@ -797,10 +797,10 @@ namespace Inferno::Editor {
                             other->SetFlag(flag, w->HasFlag(flag));
 
                         for (auto& markedId : GetSelectedWalls()) {
-                            auto& markedWall = level.GetWall(markedId);
+                            auto& markedWall = level.Walls[markedId];
                             markedWall.SetFlag(flag, w->HasFlag(flag));
 
-                            auto markedOther = level.TryGetWall(level.GetConnectedWall(markedId));
+                            auto markedOther = level.Walls.TryGetWall(level.GetConnectedWall(markedId));
                             if (Settings::Editor.EditBothWallSides && markedOther && markedOther->Type == markedWall.Type)
                                 markedOther->SetFlag(flag, w->HasFlag(flag));
                         }
@@ -825,11 +825,11 @@ namespace Inferno::Editor {
                                 other->HitPoints = wall->HitPoints;
 
                             for (auto& markedId : GetSelectedWalls()) {
-                                auto markedWall = level.TryGetWall(markedId);
+                                auto markedWall = level.Walls.TryGetWall(markedId);
                                 if (markedWall && markedWall->Type == WallType::Destroyable)
                                     markedWall->HitPoints = wall->HitPoints;
 
-                                auto markedOther = level.TryGetWall(level.GetConnectedWall(markedId));
+                                auto markedOther = level.Walls.TryGetWall(level.GetConnectedWall(markedId));
                                 if (Settings::Editor.EditBothWallSides && markedOther && markedOther->Type == WallType::Destroyable)
                                     markedOther->HitPoints = wall->HitPoints;
                             }
@@ -855,11 +855,11 @@ namespace Inferno::Editor {
                                 other->Keys = wall->Keys;
 
                             for (auto& markedId : GetSelectedWalls()) {
-                                auto markedWall = level.TryGetWall(markedId);
+                                auto markedWall = level.Walls.TryGetWall(markedId);
                                 if (markedWall && markedWall->Type == WallType::Door)
                                     markedWall->Keys = wall->Keys;
 
-                                auto markedOther = level.TryGetWall(level.GetConnectedWall(markedId));
+                                auto markedOther = level.Walls.TryGetWall(level.GetConnectedWall(markedId));
                                 if (Settings::Editor.EditBothWallSides && markedOther && markedOther->Type == WallType::Door)
                                     markedOther->Keys = wall->Keys;
                             }
@@ -894,11 +894,11 @@ namespace Inferno::Editor {
                                 other->CloakValue(cloakValue / 100);
 
                             for (auto& markedId : GetSelectedWalls()) {
-                                auto markedWall = level.TryGetWall(markedId);
+                                auto markedWall = level.Walls.TryGetWall(markedId);
                                 if (markedWall && markedWall->Type == WallType::Cloaked)
                                     markedWall->CloakValue(cloakValue / 100);
 
-                                auto markedOther = level.TryGetWall(level.GetConnectedWall(markedId));
+                                auto markedOther = level.Walls.TryGetWall(level.GetConnectedWall(markedId));
                                 if (Settings::Editor.EditBothWallSides && markedOther && markedOther->Type == WallType::Cloaked)
                                     markedOther->CloakValue(cloakValue / 100);
                             }
@@ -914,7 +914,7 @@ namespace Inferno::Editor {
                 ImGui::TableRowLabel("Blocks Light");
                 if (WallLightDropdown(wall->BlocksLight)) {
                     for (auto& wid : GetSelectedWalls()) {
-                        if (auto w = level.TryGetWall(wid)) {
+                        if (auto w = level.Walls.TryGetWall(wid)) {
                             w->BlocksLight = wall->BlocksLight;
                             auto cw = level.GetConnectedWall(*w);
                             if (Settings::Editor.EditBothWallSides && cw)

--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -265,6 +265,16 @@ namespace Inferno::Editor {
             ImGui::SameLine();
             ImGui::SetNextItemWidth(150 * Shell::DpiScale);
             ImGui::Combo("##texpreview", (int*)&_texturePreviewSize, "Small\0Medium\0Large");
+
+            ImGui::BeginChild("right", { Width / 2 - 25, columnHeight });
+            ImGui::Columns(1);
+            ImGui::EndChild();
+            {
+                ImGui::Checkbox("Use shared closed walls", &_editor.UseSharedClosedWalls);
+                ImGui::HelpMarker("All closed walls without trigger are shared as one wall.\nThis way a level can contain unlimited number of closed walls.");
+                ImGui::NextColumn();
+            }
+
             ImGui::EndTabItem();
         }
 
@@ -488,6 +498,19 @@ namespace Inferno::Editor {
 
             if (_graphics.MsaaSamples != Settings::Graphics.MsaaSamples) {
                 resourcesChanged = true;
+            }
+            if (_editor.UseSharedClosedWalls != Settings::Editor.UseSharedClosedWalls) {
+                try {
+                    //throws if not possible
+                    Inferno::Game::Level.Walls.SerializationKind(_editor.UseSharedClosedWalls 
+                                                                 ? WallsSerialization::SHARED_SIMPLE_WALLS 
+                                                                 : WallsSerialization::STANDARD);
+                }
+                catch (Exception const& e) {
+                    _editor.UseSharedClosedWalls = Settings::Editor.UseSharedClosedWalls;
+                    SPDLOG_ERROR(e.what());
+                    ShowErrorMessage(e);
+                }
             }
 
             Settings::Inferno = _inferno;

--- a/src/Inferno/Editor/UI/SettingsDialog.h
+++ b/src/Inferno/Editor/UI/SettingsDialog.h
@@ -247,7 +247,6 @@ namespace Inferno::Editor {
                 ImGui::SliderInt("##Background", &_graphics.BackgroundFpsLimit, 1, 30);
                 ImGui::NextColumn();
             }
-
             ImGui::Columns(1);
             ImGui::EndChild();
 
@@ -266,15 +265,10 @@ namespace Inferno::Editor {
             ImGui::SetNextItemWidth(150 * Shell::DpiScale);
             ImGui::Combo("##texpreview", (int*)&_texturePreviewSize, "Small\0Medium\0Large");
 
-            ImGui::BeginChild("right", { Width / 2 - 25, columnHeight });
-            ImGui::Columns(1);
-            ImGui::EndChild();
-            {
-                ImGui::Checkbox("Use shared closed walls", &_editor.UseSharedClosedWalls);
-                ImGui::HelpMarker("All closed walls without trigger are shared as one wall.\nThis way a level can contain unlimited number of closed walls.");
-                ImGui::NextColumn();
-            }
-
+            ImGui::Checkbox("Use shared closed walls", &_editor.UseSharedClosedWalls);
+            ImGui::HelpMarker("All closed walls without trigger are shared as one wall.\nThis way a level can contain unlimited number of closed walls.");
+            ImGui::NextColumn();
+            
             ImGui::EndTabItem();
         }
 

--- a/src/Inferno/Editor/UI/StatusBar.h
+++ b/src/Inferno/Editor/UI/StatusBar.h
@@ -122,7 +122,7 @@ namespace Inferno::Editor {
                 ImGui::TableNextColumn();
                 ImGui::Text("Walls");
                 ImGui::TableNextColumn();
-                ImGui::Text("%i", level.Walls.size());
+                ImGui::Text("%i (%i)", level.Walls.Size(), level.Walls.ShrinkableSize());
 
                 ImGui::EndTable();
             }

--- a/src/Inferno/Game.Wall.cpp
+++ b/src/Inferno/Game.Wall.cpp
@@ -78,11 +78,11 @@ namespace Inferno {
     }
 
     void DoOpenDoor(Level& level, ActiveDoor& door, float dt) {
-        auto& wall = level.GetWall(door.Front);
+        auto& wall = level.Walls[door.Front];
         auto conn = level.GetConnectedSide(wall.Tag);
         auto& side = level.GetSide(wall.Tag);
         auto& cside = level.GetSide(conn);
-        auto& cwall = level.GetWall(cside.Wall);
+        auto& cwall = level.Walls[cside.Wall];
 
         // todo: remove objects stuck on door
 
@@ -117,10 +117,10 @@ namespace Inferno {
     }
 
     void DoCloseDoor(Level& level, ActiveDoor& door, float dt) {
-        auto& wall = level.GetWall(door.Front);
+        auto& wall = level.Walls[door.Front];
 
-        auto front = level.TryGetWall(door.Front);
-        auto back = level.TryGetWall(door.Back);
+        auto front = level.Walls.TryGetWall(door.Front);
+        auto back = level.Walls.TryGetWall(door.Back);
 
         auto conn = level.GetConnectedSide(wall.Tag);
         auto& side = level.GetSide(wall.Tag);
@@ -173,12 +173,12 @@ namespace Inferno {
     void OpenDoor(Level& level, Tag tag) {
         auto& seg = level.GetSegment(tag);
         auto& side = seg.GetSide(tag.Side);
-        auto wall = level.TryGetWall(side.Wall);
+        auto wall = level.Walls.TryGetWall(side.Wall);
         if (!wall) throw Exception("Tried to open door on side that has no wall");
 
         auto conn = level.GetConnectedSide(tag);
         auto cwallId = level.TryGetWallID(conn);
-        auto cwall = level.TryGetWall(cwallId);
+        auto cwall = level.Walls.TryGetWall(cwallId);
 
         if (wall->State == WallState::DoorOpening ||
             wall->State == WallState::DoorWaiting)
@@ -236,7 +236,7 @@ namespace Inferno {
 
     void UpdateDoors(Level& level, float dt) {
         for (auto& door : level.ActiveDoors) {
-            auto wall = level.TryGetWall(door.Front);
+            auto wall = level.Walls.TryGetWall(door.Front);
             if (!wall) continue;
 
             if (wall->State == WallState::DoorOpening) {

--- a/src/Inferno/Game.h
+++ b/src/Inferno/Game.h
@@ -6,7 +6,7 @@
 
 namespace Inferno::Game {
     // The loaded level. Only one level can be active at a time.
-    inline Inferno::Level Level;
+    inline Inferno::Level Level{ 1, WallsSerialization::STANDARD };
 
     // The loaded mission. Not always present.
     inline Option<HogFile> Mission;

--- a/src/Inferno/Graphics/LevelMesh.cpp
+++ b/src/Inferno/Graphics/LevelMesh.cpp
@@ -231,7 +231,7 @@ namespace Inferno {
                 if (seg.GetConnection(sideId) == SegID::Exit)
                     continue;
 
-                auto wall = level.TryGetWall(side.Wall);
+                auto wall = level.Walls.TryGetWall(side.Wall);
                 WallType wallType = wall ? wall->Type : WallType::None;
 
                 // Do not render fly-through walls

--- a/src/Inferno/Graphics/MaterialLibrary.cpp
+++ b/src/Inferno/Graphics/MaterialLibrary.cpp
@@ -134,7 +134,7 @@ namespace Inferno::Render {
                 }
 
                 // Door clips
-                if (auto wall = level.TryGetWall(side.Wall)) {
+                if (auto wall = level.Walls.TryGetWall(side.Wall)) {
                     auto& wclip = Resources::GetDoorClip(wall->Clip);
                     auto wids = Seq::map(wclip.GetFrames(), Resources::LookupTexID);
                     Seq::insert(ids, wids);

--- a/src/Inferno/LevelSettings.cpp
+++ b/src/Inferno/LevelSettings.cpp
@@ -138,8 +138,8 @@ namespace Inferno {
     void SaveWallInfo(ryml::NodeRef node, const Level& level) {
         node |= ryml::SEQ;
 
-        for (int id = 0; id < level.Walls.size(); id++) {
-            auto& wall = level.Walls[id];
+        for (int id = 0; id < level.Walls.Size(); id++) {
+            auto& wall = level.Walls[static_cast<WallID>(id)];
             if (wall.BlocksLight) {
                 auto child = node.append_child();
                 child |= ryml::MAP;
@@ -156,7 +156,7 @@ namespace Inferno {
             auto id = WallID::None;
             ReadValue(child["ID"], (int16&)id);
 
-            if (auto wall = level.TryGetWall(id)) {
+            if (auto wall = level.Walls.TryGetWall(id)) {
                 bool blocksLight = false;
                 ReadValue(child["BlocksLight"], blocksLight);
                 wall->BlocksLight = blocksLight;

--- a/src/Inferno/Resources.cpp
+++ b/src/Inferno/Resources.cpp
@@ -590,7 +590,10 @@ namespace Inferno::Resources {
             throw Exception("File not found");
         }
 
-        auto level = Level::Deserialize(data);
+        auto level = Level::Deserialize(data,
+                                        Settings::Editor.UseSharedClosedWalls
+                                        ? WallsSerialization::SHARED_SIMPLE_WALLS
+                                        : WallsSerialization::STANDARD);
         level.FileName = name;
         return level;
     }

--- a/src/Inferno/Settings.cpp
+++ b/src/Inferno/Settings.cpp
@@ -250,6 +250,7 @@ namespace Inferno {
         node["TexturePreviewSize"] << (int)s.TexturePreviewSize;
         node["ShowLevelTitle"] << s.ShowLevelTitle;
         node["Descent3Mode"] << s.Descent3Mode;
+        node["UseSharedClosedWalls"] << s.UseSharedClosedWalls;
 
         SaveSelectionSettings(node["Selection"], s.Selection);
         SaveOpenWindows(node["Windows"], s.Windows);
@@ -326,6 +327,7 @@ namespace Inferno {
         ReadValue(node["TexturePreviewSize"], (int&)s.TexturePreviewSize);
         ReadValue(node["ShowLevelTitle"], s.ShowLevelTitle);
         ReadValue(node["Descent3Mode"], s.Descent3Mode);
+        ReadValue(node["UseSharedClosedWalls"], s.UseSharedClosedWalls);
 
         s.Selection = LoadSelectionSettings(node["Selection"]);
         s.Windows = LoadOpenWindows(node["Windows"]);

--- a/src/Inferno/Settings.h
+++ b/src/Inferno/Settings.h
@@ -54,6 +54,7 @@ namespace Inferno {
         float TranslationSnap = 5, RotationSnap = 0;
         Editor::CoordinateSystem CoordinateSystem{};
         Editor::TexturePreviewSize TexturePreviewSize = Editor::TexturePreviewSize::Medium;
+        bool UseSharedClosedWalls = false;
 
         LightSettings Lighting;
         float MouselookSensitivity = 0.005f; // Editor mouselook


### PR DESCRIPTION
This change allows to create unlimited amount of Closed (and not being targets of any trigger) walls. All segment sides with such walls can reference the same single wall in the saved file. The only catch I have noticed so far is that if some closed wall is a target of an "Open/Close Wall" trigger, the other side of this wall must also be a target of this trigger. Otherwise the trigger removes all closed walls in the level.

This functionality is configurable and a file once saved with "shared" closed walls can be read and saved as a "standard" file again if the number of walls does not exceed the limit. I was only able to test it with the d2x-rebirth!

Also there is a fix for a preexisting bug that decremented TriggerID::None values when removing a trigger. For that there is also code in the LevelReader that fixes the corrupted files (unless, of cause, the decremented trigger id became an existing one). The code marked as "temporary repair" and in principle can be removed.