### PR TITLE
Make all TMap1-using doors override their wall's textures on level load

### DIFF
--- a/src/Inferno/Resources.cpp
+++ b/src/Inferno/Resources.cpp
@@ -1375,6 +1375,18 @@ namespace Inferno::Resources {
             //    }
             //}
 
+            // Doors that use TMap1 override their side's textures on level load
+            for (auto& wall : level.Walls) {
+                if (wall.Clip != DClipID::None) {
+                    auto& clip = Resources::GetDoorClip(wall.Clip);
+                    if (clip.HasFlag(DoorClipFlag::TMap1)) {
+                        auto& side = level.GetSide(wall.Tag);
+                        side.TMap = clip.Frames[0];
+                        side.TMap2 = LevelTexID::Unset;
+                    }
+                }
+            }
+
             Materials = { Render::MATERIAL_COUNT };
 
             for (auto& obj : level.Objects) {


### PR DESCRIPTION
Fixes display issue with hostage doors on Reetus Mission level 1, likely others; this is accurate behaviour, surprisingly