### PR TITLE
Majority of projectile ricochet implementation

### DIFF
--- a/src/Inferno.Core/Object.h
+++ b/src/Inferno.Core/Object.h
@@ -66,6 +66,7 @@ namespace Inferno {
         PointCollideWalls = 1 << 11, // Use raycasting against walls, otherwise use spheres
         Gravity = 1 << 12, // Apply gravity
         NoCollideRobots = 1 << 13, // Ignore collisions with robots, used by robots contained in robots.
+        RandomBounce = 1 << 14, // can randomly bounce when hitting walls
     };
 
     enum class PowerupID : uint8 {

--- a/src/Inferno.Core/Weapon.h
+++ b/src/Inferno.Core/Weapon.h
@@ -157,6 +157,10 @@ namespace Inferno {
         float HomingDistance = 300; // Distance to look for new targets
         bool DirectDamage = true; // Enables direct damage on a hit. Disable for explosive weapons to make only the explosion do damage.
         bool UseThrust = false; // Uses thrust value
+
+        float RicochetChance = 0;                // Percentage chance to ricochet off walls
+        float RicochetAngle = 30;                // Angle below which ricochets begin, maximum chance is reached at 1/3 of angle
+        float RicochetMetalMultiplier = 3;       // Multiplier of metalness to both chance and angle
     };
 
     struct Weapon {

--- a/src/Inferno/Game.Wall.cpp
+++ b/src/Inferno/Game.Wall.cpp
@@ -806,7 +806,7 @@ namespace Inferno {
             return;
         }
 
-        auto bounce = hit.Bounced;
+        auto bounce = hit.Bounce != BounceType::None;
         if (hitLava && weapon.SplashRadius > 0)
             bounce = false; // Explode bouncing explosive weapons (mines) when touching lava
 

--- a/src/Inferno/Game.Weapon.cpp
+++ b/src/Inferno/Game.Weapon.cpp
@@ -402,6 +402,8 @@ namespace Inferno::Game {
             SetFlag(bullet.Physics.Flags, PhysicsFlag::UseThrust);
 
         bullet.Physics.Flags |= weapon.Bounce > 0 ? PhysicsFlag::Bounce : PhysicsFlag::None;
+        if (weapon.Extended.RicochetChance > 0)
+            bullet.Physics.Flags |= PhysicsFlag::RandomBounce;
         bullet.Physics.AngularVelocity = weapon.Extended.RotationalVelocity;
         bullet.Physics.Flags |= PhysicsFlag::FixedAngVel; // HACK
         if (weapon.Piercing) bullet.Physics.Flags |= PhysicsFlag::Piercing;

--- a/src/Inferno/GameTable.cpp
+++ b/src/Inferno/GameTable.cpp
@@ -172,6 +172,10 @@ namespace Inferno {
         READ_PROP_EXT(DirectDamage);
         READ_PROP_EXT(UseThrust);
 
+        READ_PROP_EXT(RicochetChance);
+        READ_PROP_EXT(RicochetAngle);
+        READ_PROP_EXT(RicochetMetalMultiplier);
+
         if (weapon.Extended.HomingFov > 0)
             weapon.Extended.HomingFov = ConvertFov(weapon.Extended.HomingFov);
 

--- a/src/Inferno/Graphics/Render.Level.cpp
+++ b/src/Inferno/Graphics/Render.Level.cpp
@@ -92,21 +92,6 @@ namespace Inferno::Render {
         }
     }
 
-    const TexID GetEffectTexture(EClipID id, double time, bool critical) {
-        auto& eclip = Resources::GetEffectClip(id);
-        if (eclip.TimeLeft > 0) {
-            time = eclip.VClip.PlayTime - eclip.TimeLeft;
-        }
-
-        TexID tex = eclip.VClip.GetFrame(time);
-        if (critical && eclip.CritClip != EClipID::None) {
-            auto& crit = Resources::GetEffectClip(eclip.CritClip);
-            tex = crit.VClip.GetFrame(time);
-        }
-
-        return tex;
-    }
-
     void LevelDepthCutout(ID3D12GraphicsCommandList* cmdList, const RenderCommand& cmd) {
         assert(cmd.Type == RenderCommandType::LevelMesh);
         auto& mesh = *cmd.Data.LevelMesh;
@@ -133,8 +118,8 @@ namespace Inferno::Render {
         }
 
         // Check for eclips and self destruct
-        auto tid1 = eclip1 == EClipID::None ? Resources::LookupTexID(tmap1) : GetEffectTexture(eclip1, Game::Time, Game::ControlCenterDestroyed);
-        auto tid2 = eclip2 == EClipID::None ? Resources::LookupTexID(tmap2) : GetEffectTexture(eclip2, Game::Time, Game::ControlCenterDestroyed);
+        auto tid1 = eclip1 == EClipID::None ? Resources::LookupTexID(tmap1) : Resources::GetEffectTexture(eclip1, Game::Time, Game::ControlCenterDestroyed);
+        auto tid2 = eclip2 == EClipID::None ? Resources::LookupTexID(tmap2) : Resources::GetEffectTexture(eclip2, Game::Time, Game::ControlCenterDestroyed);
 
         auto mat1 = &Materials->Get(tid1);
         auto mat2 = &Materials->Get(tid2);
@@ -322,8 +307,8 @@ namespace Inferno::Render {
             return; // No decal texture!
 
         // Check for eclips and self destruct
-        auto tid1 = eclip1 == EClipID::None ? Resources::LookupTexID(tmap1) : GetEffectTexture(eclip1, Game::Time, Game::ControlCenterDestroyed);
-        auto tid2 = eclip2 == EClipID::None ? Resources::LookupTexID(tmap2) : GetEffectTexture(eclip2, Game::Time, Game::ControlCenterDestroyed);
+        auto tid1 = eclip1 == EClipID::None ? Resources::LookupTexID(tmap1) : Resources::GetEffectTexture(eclip1, Game::Time, Game::ControlCenterDestroyed);
+        auto tid2 = eclip2 == EClipID::None ? Resources::LookupTexID(tmap2) : Resources::GetEffectTexture(eclip2, Game::Time, Game::ControlCenterDestroyed);
 
         auto mat1 = &Materials->Get(tid1);
         auto mat2 = &Materials->Get(tid2);

--- a/src/Inferno/Intersect.h
+++ b/src/Inferno/Intersect.h
@@ -12,6 +12,11 @@ namespace Inferno {
         explicit operator bool() const { return Distance != FLT_MAX; }
     };
 
+    struct TexHitInfo {
+        LevelTexID tex = LevelTexID::Unset;
+        uint x = 0, y = 0;
+    };
+
     // Returns the nearest intersection point on a face
     HitInfo IntersectFaceSphere(const ConstFace& face, const DirectX::BoundingSphere& sphere);
     HitInfo IntersectSphereSphere(const DirectX::BoundingSphere& a, const DirectX::BoundingSphere& b);
@@ -87,6 +92,10 @@ namespace Inferno {
     // Returns the UVs on a face closest to a point in world coordinates
     Vector2 IntersectFaceUVs(const Vector3& point, const ConstFace& face, int tri);
     void FixOverlayRotation(uint& x, uint& y, int width, int height, OverlayRotation rotation);
+
+    // Uses given point to return the LevelTexID of the visible texture + coordinates at the given point, accounting for overlay transparency
+    // Returns Unset as tex if point is transparent
+    TexHitInfo GetTextureFromIntersect(const Vector3& pnt, const ConstFace& face, int tri);
 
     // Returns true if the point was transparent
     bool WallPointIsTransparent(const Vector3& pnt, const ConstFace& face, int tri);

--- a/src/Inferno/Intersect.h
+++ b/src/Inferno/Intersect.h
@@ -13,7 +13,7 @@ namespace Inferno {
     };
 
     struct TexHitInfo {
-        LevelTexID tex = LevelTexID::Unset;
+        TexID tex = TexID::None;
         uint x = 0, y = 0;
     };
 
@@ -21,6 +21,12 @@ namespace Inferno {
     HitInfo IntersectFaceSphere(const ConstFace& face, const DirectX::BoundingSphere& sphere);
     HitInfo IntersectSphereSphere(const DirectX::BoundingSphere& a, const DirectX::BoundingSphere& b);
     HitInfo IntersectPointSphere(const Vector3& point, const DirectX::BoundingSphere& sphere);
+
+    enum class BounceType {
+        None = 0,
+        Standard = 1,       // Projectile is of a bouncing type
+        Random = 2          // Projectile passed random bounce check
+    };
 
     struct LevelHit {
         Object* Source = nullptr;
@@ -32,7 +38,9 @@ namespace Inferno {
         Vector3 Normal, Tangent;
         int Tri = -1; // Triangle of the face hit. -1, 0 or 1
         float Speed = 0;
-        bool Bounced = false;
+        BounceType Bounce = BounceType::None;
+        float BounceAngle = 0; // relevant for random bounces, to prevent bouncing directly into hit surface
+        TexHitInfo TexHit;
 
         // Returns true if either object hit is the player
         bool PlayerHit() const {
@@ -93,8 +101,8 @@ namespace Inferno {
     Vector2 IntersectFaceUVs(const Vector3& point, const ConstFace& face, int tri);
     void FixOverlayRotation(uint& x, uint& y, int width, int height, OverlayRotation rotation);
 
-    // Uses given point to return the LevelTexID of the visible texture + coordinates at the given point, accounting for overlay transparency
-    // Returns Unset as tex if point is transparent
+    // Uses given point to return the TexID of the visible texture + coordinates at the given point, accounting for overlay transparency
+    // Returns None as tex if point is transparent
     TexHitInfo GetTextureFromIntersect(const Vector3& pnt, const ConstFace& face, int tri);
 
     // Returns true if the point was transparent

--- a/src/Inferno/Resources.cpp
+++ b/src/Inferno/Resources.cpp
@@ -236,6 +236,21 @@ namespace Inferno::Resources {
             return info.DestroyedTexture;
     }
 
+    const TexID GetEffectTexture(EClipID id, double time, bool critical) {
+        auto& eclip = Resources::GetEffectClip(id);
+        if (eclip.TimeLeft > 0) {
+            time = eclip.VClip.PlayTime - eclip.TimeLeft;
+        }
+
+        TexID tex = eclip.VClip.GetFrame(time);
+        if (critical && eclip.CritClip != EClipID::None) {
+            auto& crit = Resources::GetEffectClip(eclip.CritClip);
+            tex = crit.VClip.GetFrame(time);
+        }
+
+        return tex;
+    }
+
     PigEntry DefaultPigEntry = { .Name = "Unknown", .Width = 64, .Height = 64 };
 
     TexID FindTexture(string_view name) {

--- a/src/Inferno/Resources.h
+++ b/src/Inferno/Resources.h
@@ -69,6 +69,7 @@ namespace Inferno::Resources {
     const PigEntry& GetTextureInfo(TexID);
     const PigEntry& GetTextureInfo(LevelTexID);
     LevelTexID GetDestroyedTexture(LevelTexID);
+    const TexID GetEffectTexture(EClipID id, double time, bool critical);
 
     const Model& GetModel(ModelID);
     const Model& GetModel(const Object&);

--- a/src/Inferno/d1/game.yml
+++ b/src/Inferno/d1/game.yml
@@ -189,6 +189,10 @@ Weapons:
     FlashColor: 1, 0.6, .3, 1
     StunMult: 2 # Increase slow so vulcan can tag small fast enemies
     Size: 0.75
+    RicochetChance: 20
+    RicochetAngle: 30
+    RicochetMetalMultiplier: 3
+    Bounces: 3
     
   - id: 12 
     Name: spreadfire


### PR DESCRIPTION
Also shifts GetEffectTexture to Resources, in order to fix weapon-to-wall transparency testing with animated textures