### PR TITLE
Joystick fix

### DIFF
--- a/src/Inferno/Game.Bindings.cpp
+++ b/src/Inferno/Game.Bindings.cpp
@@ -104,6 +104,34 @@ namespace Inferno {
                 }
                 break;
             case Input::InputType::Joystick:
+                switch (binding->type) {
+                    case BindType::None:
+                        return "";
+                    case BindType::Button:
+                        return fmt::format("B{}", binding->id);
+                    case BindType::Axis:
+                        return fmt::format("AXIS {}", binding->id);
+                    case BindType::AxisPlus:
+                        return fmt::format("AXIS {}+", binding->id);
+                    case BindType::AxisMinus:
+                        return fmt::format("AXIS {}-", binding->id);
+                    case BindType::AxisButtonPlus:
+                        return fmt::format("AXIS {}+", binding->id);
+                    case BindType::AxisButtonMinus:
+                        return fmt::format("AXIS {}-", binding->id);
+                    case BindType::Hat:
+                        switch ((Input::HatDirection)binding->id) {
+                            case Input::HatDirection::Left:
+                                return "HAT-L";
+                            case Input::HatDirection::Right:
+                                return "HAT-R";
+                            case Input::HatDirection::Up:
+                                return "HAT-U";
+                            case Input::HatDirection::Down:
+                                return "HAT-D";
+                        }
+                        break;
+                }
                 break;
             }
         }

--- a/src/Inferno/Game.Bindings.cpp
+++ b/src/Inferno/Game.Bindings.cpp
@@ -208,10 +208,10 @@ namespace Inferno {
                     auto sensitivity = deviceBindings.sensitivity.GetSensitivity(action);
 
                     if (binding.type == BindType::AxisPlus) {
-                        value += Input::LinearDampen(device->axes[binding.id], deadzone, 1) * invert * sensitivity;
+                        value += Input::LinearDampen(device->axes[binding.id], deadzone, 1, sensitivity) * invert;
                     }
                     else if (binding.type == BindType::AxisMinus) {
-                        value += Input::LinearDampen(device->axes[binding.id], deadzone, 1) * invert * sensitivity;
+                        value += Input::LinearDampen(device->axes[binding.id], deadzone, 1, sensitivity) * invert;
                     }
                     else if (binding.type == BindType::Axis) {
                         if (device->type != SDL_GAMEPAD_TYPE_UNKNOWN) {
@@ -231,7 +231,7 @@ namespace Inferno {
                                 value += stick.y * invert;
                         }
                         else {
-                            value += Input::LinearDampen(device->axes[binding.id], deadzone, 1) * invert * sensitivity;
+                            value += Input::LinearDampen(device->axes[binding.id], deadzone, 1, sensitivity) * invert;
                         }
                     }
                 }

--- a/src/Inferno/Game.Bindings.h
+++ b/src/Inferno/Game.Bindings.h
@@ -239,6 +239,10 @@ namespace Inferno {
                 for (size_t g = 0; g < group.size(); g++) {
                     auto& existing = group[g];
 
+                    if ((existing.type == BindType::Hat && binding.type != BindType::Hat) ||
+                        (binding.type == BindType::Hat && existing.type != BindType::Hat))
+                        continue; // skip mismatched types
+
                     if ((existing.type == BindType::Button && binding.type != BindType::Button) ||
                         (binding.type == BindType::Button && existing.type != BindType::Button))
                         continue; // skip mismatched types (only compare buttons to buttons, and non-buttons to other non-buttons)

--- a/src/Inferno/Game.UI.Bindings.h
+++ b/src/Inferno/Game.UI.Bindings.h
@@ -156,7 +156,7 @@ namespace Inferno::UI {
                                 binding.type = BindType::Button;
                                 finishBinding();
                             }
-
+                            
                             if (joystick->CheckAxisPressed(bindId, dir)) {
                                 // this doesn't seem necessary anymore, tested on PS5 and xbox controllers
                                 //bool halfAxis = bindId == SDL_GAMEPAD_AXIS_LEFT_TRIGGER || bindId == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER;
@@ -187,6 +187,11 @@ namespace Inferno::UI {
                             if (joystick->CheckButtonDown(bindId)) {
                                 binding.id = bindId;
                                 binding.type = BindType::Button;
+                                finishBinding();
+                            }
+                            if (joystick->CheckHat(bindId)) {
+                                binding.id = bindId;
+                                binding.type = BindType::Hat;
                                 finishBinding();
                             }
                         }

--- a/src/Inferno/Game.UI.Options.h
+++ b/src/Inferno/Game.UI.Options.h
@@ -159,9 +159,9 @@ namespace Inferno::UI {
                 if (auto device = Seq::tryItem(_devices, *_index - 2)) {
                     if (auto bindings = Game::Bindings.GetDevice(device->guid)) {
                         auto& rotation = bindings->sensitivity.rotation;
-                        addSlider("Pitch", 0.0f, 2.0f, rotation.x);
-                        addSlider("Yaw", 0.0f, 2.0f, rotation.y);
-                        addSlider("Roll", 0.0f, 2.0f, rotation.z);
+                        addSlider("Pitch", 1.0f, 5.0f, rotation.x);
+                        addSlider("Yaw", 1.0f, 5.0f, rotation.y);
+                        addSlider("Roll", 1.0f, 5.0f, rotation.z);
 
                         auto& thrust = bindings->sensitivity.thrust;
                         addSlider("fwd/Rev", 0.0f, 2.0f, thrust.z);

--- a/src/Inferno/Input.cpp
+++ b/src/Inferno/Input.cpp
@@ -159,10 +159,13 @@ namespace Inferno::Input {
         return input * Saturate(scale) / magnitude;
     }
 
-    float LinearDampen(float value, float innerDeadzone, float outerDeadzone) {
-        if (value <= 0.0001f) return 0;
-        float scale = (value - innerDeadzone) / (outerDeadzone - innerDeadzone);
-        return Saturate(scale);
+    float LinearDampen(float value, float innerDeadzone, float outerDeadzone, float linearity) {
+        if (abs(value) <= innerDeadzone) return 0;
+        //else if (value < -1) value = -1;
+        //else if (value > 1) value = 1;
+        float sign = value < 0 ? -1 : 1;
+        float magnitude = (abs(value) - innerDeadzone) / (1 - innerDeadzone) * (1 - 0) + 0;
+        return pow(magnitude,linearity) * sign;
     }
 
     // Maps an axis to -1 to 1

--- a/src/Inferno/Input.h
+++ b/src/Inferno/Input.h
@@ -279,7 +279,7 @@ namespace Inferno::Input {
     inline std::function<void(InputDevice&)> AddDeviceCallback;
 
     Vector2 CircularDampen(const Vector2& input, float innerDeadzone, float outerDeadzone);
-    float LinearDampen(float value, float innerDeadzone, float outerDeadzone);
+    float LinearDampen(float value, float innerDeadzone, float outerDeadzone, float linearity);
 
     enum class MouseButtons : uint8_t {
         None,

--- a/src/Inferno/Input.h
+++ b/src/Inferno/Input.h
@@ -168,6 +168,18 @@ namespace Inferno::Input {
 
             return false;
         }
+        
+        // Returns true if hat is pressed in a direction. Returns direction through parameter.
+        bool CheckHat(uint8& hat) const {
+            for (uint8 i = 1; i <= 4; i++) {
+                if (HatDirection(Input::HatDirection(i))) {
+                    hat = i;
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         bool CheckButtonDown(uint8& button) const {
             for (uint8 i = 0; i < buttonPressed.size(); i++) {


### PR DESCRIPTION
Includes a number of fixes to make Joystick usable
- Negative axis values are now registered
- Inner dead zones are now properly applied
- Changed sensitivity to linearity for rotations (still called "sensitivity")
- Refactored sensitivity calculation into LinearDampen() function, which now has +1 argument called "linearity"
- Clamped sensitivity slider in UI for rotations between 1.0 to 5.0, default is 1.0, higher is more progressive input
- Joystick input labeling added
- HAT input binding added

TODO: HAT input currently registers input every frame, needs a release-check (neutral HAT direction is 0)