### PR TITLE
Fix objects leaving the level via an "end of exit tunnel" side causing crashes

### DIFF
--- a/src/Inferno/Game.Object.cpp
+++ b/src/Inferno/Game.Object.cpp
@@ -186,12 +186,13 @@ namespace Inferno {
 
         auto id = TraceSegment(level, obj.Segment, obj.Position);
 
-        if ((id == SegID::None || id == SegID::Exit) && obj.Segment == Game::Terrain.ExitTag.Segment) {
-            id = SegID::Terrain; // Assume that the object has entered the terrain
-        }
-        else if (id == SegID::None) {
-            SetFlag(obj.Flags, ObjectFlag::OutOfBounds);
-            return false;
+        if (id == SegID::None || id == SegID::Exit) {
+            if (obj.Segment == Game::Terrain.ExitTag.Segment)
+                id = SegID::Terrain; // Assume that the object has entered the terrain
+            else {
+                SetFlag(obj.Flags, ObjectFlag::OutOfBounds);
+                return false;
+            }
         }
 
         auto ref = Game::GetObjectRef(obj);


### PR DESCRIPTION
It's possible that making said sides solid may be a safer option (I'm sure I've seen at least one level where such a side is physically reachable via the player during gameplay), but this at least seems to fix the crashes easily.